### PR TITLE
avoid allocations: use a Cstruct.t list for sndq and rcvq

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ Model anomalies:
 - when is t_maxseg set? is it modified at all? (should not be once ESTABLISHED is reached)
 - t_badrxtwin <- meh (don't understand its value and usage)
 - really need to ensure that we're not talking to ourselves in Segment.decode_and_verify...
-- further avoiding allocations: sndq and rcvq should be lists of cstruct (no need for Cstruct.append!)
 - the rcv_window computations are done for bad segments (di_2a/7c/7d) on BSD as well, but we don't need that behaviour
 - verify with RFC 9293 at hand
 - appropriate byte counting (RFC 3456, not in the HOL4 model, though :/)

--- a/src/segment.ml
+++ b/src/segment.ml
@@ -468,7 +468,8 @@ let tcp_output_really now (src, src_port, dst, dst_port) window_probe conn =
     snd_nxt = snd_nxt' ;
     tt_delack = None ;
     last_ack_sent = cb.State.rcv_nxt ;
-    rcv_adv = Sequence.addi cb.State.rcv_nxt rcv_wnd'
+    rcv_adv = Sequence.addi cb.State.rcv_nxt rcv_wnd' ;
+    rcv_wnd = rcv_wnd' ;
   } in
   { conn with tcp_state ; control_block }, (src, dst, seg)
 

--- a/src/subr.ml
+++ b/src/subr.ml
@@ -72,7 +72,7 @@ let calculate_buf_sizes (* conn *) cb_t_maxseg seg_mss bw_delay_product_for_rt r
 
 let calculate_bsd_rcv_wnd conn =
   max (Sequence.window conn.control_block.rcv_adv conn.control_block.rcv_nxt)
-    (conn.rcvbufsize - Cstruct.length conn.rcvq)
+    (conn.rcvbufsize - Cstruct.lenv conn.rcvq)
 
 let update_rtt rtt ri =
   let rtt = Mtime.Span.to_uint64_ns rtt in

--- a/src/user.ml
+++ b/src/user.ml
@@ -112,7 +112,7 @@ let send t now id buf =
     let conn', out = Segment.tcp_output_perhaps now id conn' in
     Ok ({ t with connections = CM.add id conn' t.connections }, out)
 
-let recv t id =
+let recv t now id =
   match CM.find_opt id t.connections with
   | None -> Error (`Msg "no connection")
   | Some conn ->
@@ -122,4 +122,5 @@ let recv t id =
     let rcvq = Cstruct.concat (List.rev conn.rcvq) in
     let* () = guard (not (Cstruct.length rcvq = 0 && conn.cantrcvmore)) `Eof in
     let conn' = { conn with rcvq = [] } in
-    Ok ({ t with connections = CM.add id conn' t.connections }, rcvq)
+    let conn', out = Segment.tcp_output_perhaps now id conn' in
+    Ok ({ t with connections = CM.add id conn' t.connections }, rcvq, out)

--- a/src/utcp.mli
+++ b/src/utcp.mli
@@ -87,7 +87,8 @@ val close : state -> Mtime.t -> flow ->
 val shutdown : state -> Mtime.t -> flow -> [ `read | `write | `read_write ] ->
   (state * output option, [ `Msg of string ]) result
 
-val recv : state -> flow -> (state * Cstruct.t, [ `Msg of string | `Eof ]) result
+val recv : state -> Mtime.t -> flow ->
+  (state * Cstruct.t * output option, [ `Msg of string | `Eof ]) result
 
 val send : state -> Mtime.t -> flow -> Cstruct.t ->
   (state * output option, [ `Msg of string ]) result

--- a/src/utcp.mli
+++ b/src/utcp.mli
@@ -177,8 +177,8 @@ module State : sig
     cantsndmore : bool ;
     rcvbufsize : int ;
     sndbufsize : int ;
-    sndq : Cstruct.t ;
-    rcvq : Cstruct.t ;
+    sndq : Cstruct.t list ;
+    rcvq : Cstruct.t list ;
   }
   val conn_state : rcvbufsize:int -> sndbufsize:int -> tcp_state ->
     control_block -> conn_state

--- a/test/state_machine.ml
+++ b/test/state_machine.ml
@@ -97,22 +97,26 @@ let equal_tcp_state a b = match a, b with
   | Time_wait, Time_wait -> true
   | _ -> false
 
+let leq f a b =
+  List.length a = List.length b &&
+  List.for_all2 f a b
+
 let equal_conn_state_full a b =
   equal_tcp_state a.State.tcp_state b.State.tcp_state &&
   a.cantrcvmore = b.cantrcvmore &&
   a.cantsndmore = b.cantsndmore &&
   a.rcvbufsize = b.rcvbufsize &&
   a.sndbufsize = b.sndbufsize &&
-  Cstruct.equal a.sndq b.sndq &&
-  Cstruct.equal a.rcvq b.rcvq &&
+  leq Cstruct.equal a.sndq b.sndq &&
+  leq Cstruct.equal a.rcvq b.rcvq &&
   equal_control_block a.control_block b.control_block
 
 let equal_conn_state a b =
   equal_tcp_state a.State.tcp_state b.State.tcp_state &&
   a.cantrcvmore = b.cantrcvmore &&
   a.cantsndmore = b.cantsndmore &&
-  Cstruct.equal a.sndq b.sndq &&
-  Cstruct.equal a.rcvq b.rcvq
+  leq Cstruct.equal a.sndq b.sndq &&
+  leq Cstruct.equal a.rcvq b.rcvq
 
 let equal_tcp_full a b =
   State.IS.equal a.State.listeners b.State.listeners &&

--- a/utcp.opam
+++ b/utcp.opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/robur-coop/utcp/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
-  "cstruct" {>= "6.0.0"}
+  "cstruct" {>= "6.0.1"}
   "duration" {>= "0.2.0"}
   "fmt" {>= "0.8.7"}
   "ipaddr" {>= "5.2.0"}


### PR DESCRIPTION
previously, Cstruct.append was used all over which allocates a lot