### PR TITLE
Use a faster implementation to calcultate the checksum

### DIFF
--- a/fuzz/dune
+++ b/fuzz/dune
@@ -1,0 +1,8 @@
+(executable
+ (name fuzz)
+ (libraries crowbar utcp))
+
+(rule
+ (alias runtest)
+ (enabled_if (= %{arch_sixtyfour} true))
+ (action (run %{dep:fuzz.exe})))

--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -1,0 +1,11 @@
+open Crowbar
+
+let buf = dynamic_bind (range 256) bytes_fixed
+let pp ppf = Format.fprintf ppf "%04x"
+
+let () =
+  add_test ~name:"checksum" [ buf ] @@ fun buf ->
+  let { Cstruct.buffer; off; len } = Cstruct.of_string buf in
+  let a = Utcp.Checksum.unsafe_digest_16 ~off ~len buffer in
+  let b = Utcp.Checksum.unsafe_digest_32 ~off ~len buffer in
+  check_eq ~pp a b

--- a/src/checksum.ml
+++ b/src/checksum.ml
@@ -1,0 +1,70 @@
+type bigstring =
+  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+
+let length x = Bigarray.Array1.dim x [@@inline]
+
+let to_int32 :
+    bigstring ->
+    (int32, Bigarray.int32_elt, Bigarray.c_layout) Bigarray.Array1.t =
+ fun ba ->
+  let len = length ba in
+  let pad = len mod 4 in
+  let buf = Bigarray.Array1.sub ba 0 (len - pad) in
+  Obj.magic buf
+
+let to_int16 :
+    bigstring ->
+    (int, Bigarray.int16_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t =
+ fun ba ->
+  let len = length ba in
+  let pad = len mod 2 in
+  let buf = Bigarray.Array1.sub ba 0 (len - pad) in
+  Obj.magic buf
+
+external unsafe_get_uint8 : bigstring -> int -> int = "%caml_ba_ref_1"
+external unsafe_get_uint16 : bigstring -> int -> int = "%caml_bigstring_get16"
+external swap16 : int -> int = "%bswap16"
+
+let unsafe_digest_16 ?(off = 0) ~len:top buf =
+  let buf16 = to_int16 buf in
+  let len = ref top in
+  let sum = ref 0 in
+  let i = ref 0 in
+  while !len >= 2 do
+    sum := !sum + buf16.{off + !i};
+    if !sum > 0xffff then incr sum;
+    sum := !sum land 0xffff;
+    incr i;
+    len := !len - 2
+  done;
+  if !len = 1 then sum := !sum + unsafe_get_uint8 buf (off + top - 1);
+  if !sum > 0xffff then incr sum;
+  swap16 (lnot !sum land 0xffff)
+
+let unsafe_digest_32 ?(off = 0) ~len:top buf =
+  let buf32 = to_int32 buf in
+  let len = ref top in
+  let sum = ref 0 in
+  let i = ref 0 in
+  while !len >= 4 do
+    let[@warning "-8"] (Some v) = Int32.unsigned_to_int buf32.{off + !i} in
+    sum := !sum + v;
+    incr i;
+    len := !len - 4
+  done;
+  if !len >= 2 then (
+    sum := !sum + unsafe_get_uint16 buf (off + (!i * 4));
+    len := !len - 2);
+  if !len = 1 then sum := !sum + unsafe_get_uint8 buf (off + top - 1);
+  while !sum lsr 16 <> 0 do
+    sum := (!sum land 0xffff) + (!sum lsr 16)
+  done;
+  swap16 (lnot !sum land 0xffff)
+
+let digest ?(off = 0) ?len buf =
+  let len = match len with Some len -> len | None -> length buf - off in
+  match Sys.word_size with
+  | 32 -> unsafe_digest_16 ~off ~len buf
+  | _ -> unsafe_digest_32 ~off ~len buf
+
+let digest_cstruct { Cstruct.buffer; off; len } = digest ~off ~len buffer

--- a/src/checksum.mli
+++ b/src/checksum.mli
@@ -1,0 +1,7 @@
+type bigstring =
+  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+
+val unsafe_digest_16 : ?off:int -> len:int -> bigstring -> int
+val unsafe_digest_32 : ?off:int -> len:int -> bigstring -> int
+val digest : ?off:int -> ?len:int -> bigstring -> int
+val digest_cstruct : Cstruct.t -> int

--- a/src/segment.ml
+++ b/src/segment.ml
@@ -576,16 +576,8 @@ let checksum ~src ~dst buf =
   Cstruct.blit buf 0 mybuf off plen;
   (* ensure checksum to be 0 *)
   Cstruct.BE.set_uint16 mybuf (off + 16) 0;
-  (* compute 2s complement 16 bit checksum *)
-  let sum = ref 0 in
   (* compute checksum *)
-  for i = 0 to pred (Cstruct.length mybuf / 2) do
-    let v = Cstruct.BE.get_uint16 mybuf (i * 2) in
-    let sum' = !sum + v in
-    let sum'' = if sum' > 0xFFFF then succ sum' else sum' in
-    sum := sum'' land 0xFFFF
-  done ;
-  (lnot !sum) land 0xFFFF
+  Checksum.digest_cstruct mybuf
 
 let encode_into buf t =
   let opt_len = length_options t.options in

--- a/src/utcp.ml
+++ b/src/utcp.ml
@@ -42,3 +42,5 @@ module State = State
 module Input = Input
 
 module User = User
+
+module Checksum = Checksum

--- a/src/utcp.mli
+++ b/src/utcp.mli
@@ -217,4 +217,6 @@ module User : sig
   val connect : src:Ipaddr.t -> ?src_port:int -> dst:Ipaddr.t -> dst_port:int ->
     State.t -> Mtime.t -> (State.t * flow * output)
 end
+
+module Checksum = Checksum
 (**/**)

--- a/utcp.opam
+++ b/utcp.opam
@@ -34,6 +34,7 @@ depends: [
   "mirage-clock-unix" {>= "3.1.0" & dev}
   "pcap-format" {>= "0.6.0" & dev}
   "alcotest" {>= "1.5.0" & with-test}
+  "crowbar" {>= "0.2.1" & with-test}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
As discussed with @hannesm, this is a fast implementation of the `checksum` which take the advantage of an `int32 Bigarray` (64-bits) or a `int16_unsigned_elt Bigarray.t` (32-bits). We use an `Obj.magic` to change the kind of the bigarray but it should be safe. A fuzzer was added (which works only on 64-bits machine) to compare `unsafe_digest_16` and `unsafe_digest_32`.

Note: I suspect an issue for huuuuuuge packets (with a payload really bigger than 1Go) mainly because we still have a 63-bits integer but it should be fine.