### PR TITLE
Segment: revise checksum to not allocate and blit

### DIFF
--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -6,6 +6,6 @@ let pp ppf = Format.fprintf ppf "%04x"
 let () =
   add_test ~name:"checksum" [ buf ] @@ fun buf ->
   let { Cstruct.buffer; off; len } = Cstruct.of_string buf in
-  let a = Utcp.Checksum.unsafe_digest_16 ~off ~len buffer in
-  let b = Utcp.Checksum.unsafe_digest_32 ~off ~len buffer in
+  let a = Utcp.Checksum.unsafe_digest_16 ~sum:0 ~off ~len buffer in
+  let b = Utcp.Checksum.unsafe_digest_32 ~sum:0 ~off ~len buffer in
   check_eq ~pp a b

--- a/src/checksum.mli
+++ b/src/checksum.mli
@@ -1,7 +1,7 @@
 type bigstring =
   (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
-val unsafe_digest_16 : ?off:int -> len:int -> bigstring -> int
-val unsafe_digest_32 : ?off:int -> len:int -> bigstring -> int
-val digest : ?off:int -> ?len:int -> bigstring -> int
-val digest_cstruct : Cstruct.t -> int
+val unsafe_digest_16 : sum:int -> off:int -> len:int -> bigstring -> int
+val unsafe_digest_32 : sum:int -> off:int -> len:int -> bigstring -> int
+val digest : ?sum:int -> ?off:int -> ?len:int -> bigstring -> int
+val digest_cstruct : ?sum:int -> Cstruct.t -> int

--- a/test/checksum.ml
+++ b/test/checksum.ml
@@ -59,7 +59,7 @@ let data5 () =
 let real1 () =
   let data = Cstruct.of_hex {|
 00 50 d0 c5 90 3b 6f b9 31 8e 90 da 70 12 ff ff
-83 98 00 00 02 04 05 b4 03 03 06 00|}
+00 00 00 00 02 04 05 b4 03 03 06 00|}
   in
   let src = Ipaddr.(V4 (V4.of_string_exn "10.0.42.2"))
   and dst = Ipaddr.(V4 (V4.of_string_exn "10.0.42.1"))


### PR DESCRIPTION
instead, allocate the pseudo-header and compute checksum of  header and payload individually

Still a bit undecided, testing this with `siege -c 1 -r 1000` on my laptop (and a retreat unikernel on the other side) results in:
mirage-tcpip (which doesn't validate any checksums): ~2000 req/s
current main (cea1509): ~1400 req/s
this head (d639adc1): ~1500 req/s
utcp without checksum verficiation: ~2300 req/s