### PR TITLE
Fix conjunction in tcp_output_really_helper, adjust to specification

### DIFF
--- a/src/segment.ml
+++ b/src/segment.ml
@@ -385,9 +385,9 @@ let tcp_output_really_helper now (src, src_port, dst, dst_port) window_probe con
       data has yet been sent over the socket  :*)
   let snd_nxt =
     if fin &&
-       Sequence.equal (Sequence.addi cb.State.snd_nxt dlen) (Sequence.incr last_sndq_data_seq) &&
-       not (Sequence.equal cb.State.snd_una cb.State.iss) ||
-       Sequence.window cb.State.snd_nxt cb.State.iss = 2
+       (Sequence.equal (Sequence.addi cb.State.snd_nxt dlen) (Sequence.incr last_sndq_data_seq) &&
+        not (Sequence.equal cb.State.snd_una cb.State.iss) ||
+        Sequence.window cb.State.snd_nxt cb.State.iss = 2)
     then
       Sequence.addi cb.State.snd_nxt (-1)
     else


### PR DESCRIPTION
Not sure if this is the right patch, but we (/cc @reynir) spent the day looking at Sequences and Acknowledge numbers to realize that at one point, the unikernel's Sequence was decrementing. The comment above specifies that this should be the case if we receive FIN, which is not our case. I think that, due to the associativity of the `||` and `&&` operators, the result of the condition becomes true and µTCP decrements the Sequence when it shouldn't. So we've just added parenthesis (by feelings).

With this fix, we can do a test with `iperf3` of our unikernel (which claims a speed of 2Mbytes/s... but that's another problem).