### PR TITLE
Use bytes instead of cstruct to construct pseudoheader and compute checksum

### DIFF
--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -6,6 +6,8 @@ let pp ppf = Format.fprintf ppf "%04x"
 let () =
   add_test ~name:"checksum" [ buf ] @@ fun buf ->
   let { Cstruct.buffer; off; len } = Cstruct.of_string buf in
-  let a = Utcp.Checksum.unsafe_digest_16_le ~off ~len buffer in
-  let b = Utcp.Checksum.unsafe_digest_32_le ~off ~len buffer in
+  let a = Utcp.Checksum.unsafe_feed_16_le ~off ~len 0 buffer in
+  let b = Utcp.Checksum.unsafe_feed_32_le ~off ~len 0 buffer in
+  let a = Utcp.Checksum.finally a in
+  let b = Utcp.Checksum.finally b in
   check_eq ~pp a b

--- a/src/checksum.ml
+++ b/src/checksum.ml
@@ -147,13 +147,12 @@ let feed_string ?(off= 0) ?len sum str =
   let len = match len with
     | Some len -> len
     | None -> String.length str - off in
-  if off < 0
-  || len < 0
-  || off > String.length str - len
-  then invalid_arg "Checksum.digest_string";
-  if Sys.big_endian
-  then unsafe_feed_string_16_be ~off ~len sum str
-  else unsafe_feed_string_16_le ~off ~len sum str
+  if off < 0 || len < 0 || off > String.length str - len then
+    invalid_arg "Checksum.digest_string";
+  if Sys.big_endian then
+    unsafe_feed_string_16_be ~off ~len sum str
+  else
+    unsafe_feed_string_16_le ~off ~len sum str
 
 let digest_string ?(off= 0) ?len str =
   let len = match len with

--- a/src/checksum.ml
+++ b/src/checksum.ml
@@ -159,14 +159,14 @@ let digest_string ?(off= 0) ?len str =
   let len = match len with
     | Some len -> len
     | None -> String.length str - off in
-  if off < 0
-  || len < 0
-  || off > String.length str - len
-  then invalid_arg "Checksum.digest_string";
+  if off < 0 || len < 0 || off > String.length str - len then
+    invalid_arg "Checksum.digest_string";
   let sum =
-    if Sys.big_endian
-    then unsafe_feed_string_16_be ~off ~len 0 str
-    else unsafe_feed_string_16_le ~off ~len 0 str in
+    if Sys.big_endian then
+      unsafe_feed_string_16_be ~off ~len 0 str
+    else
+      unsafe_feed_string_16_le ~off ~len 0 str
+  in
   finally sum
 
 let digest_strings sstr =

--- a/src/checksum.ml
+++ b/src/checksum.ml
@@ -36,10 +36,10 @@ let int32_to_int n = int32_to_int n land mask
    noted that bound-check is not the most expensive (and quite predictable in
    reality), but unbox is. *)
 
-let unsafe_digest_16_le ?(off = 0) ~len:top buf =
+let[@inline always] unsafe_feed_16_le ?(off = 0) ~len:top sum buf =
   let buf16 = to_int16 ~off ~len:top buf in
   let len = ref top in
-  let sum = ref 0 in
+  let sum = ref sum in
   let i = ref 0 in
   while !len >= 2 do
     sum := !sum + buf16.{!i};
@@ -49,14 +49,13 @@ let unsafe_digest_16_le ?(off = 0) ~len:top buf =
     len := !len - 2
   done;
   if !len = 1 then sum := !sum + unsafe_get_uint8 buf (off + top - 1);
-  if !sum > 0xffff then incr sum;
-  swap16 (lnot !sum land 0xffff)
+  !sum
 
 (* NOTE(dinosaure): only work on 64-bit architecture. *)
-let unsafe_digest_32_le ?(off = 0) ~len:top buf =
+let[@inline always] unsafe_feed_32_le ?(off = 0) ~len:top sum buf =
   let buf32 = to_int32 ~off ~len:top buf in
   let len = ref top in
-  let sum = ref 0 in
+  let sum = ref sum in
   let i = ref 0 in
   while !len >= 4 do
     let v = int32_to_int buf32.{!i} in
@@ -68,16 +67,13 @@ let unsafe_digest_32_le ?(off = 0) ~len:top buf =
     sum := !sum + unsafe_get_uint16 buf (off + (!i * 4));
     len := !len - 2);
   if !len = 1 then sum := !sum + unsafe_get_uint8 buf (off + top - 1);
-  while !sum lsr 16 <> 0 do
-    sum := (!sum land 0xffff) + (!sum lsr 16)
-  done;
-  swap16 (lnot !sum land 0xffff)
+  !sum
 
 (* NOTE(dinosaure): only work on 64-bit architecture. *)
-let unsafe_digest_32_be ?(off = 0) ~len:top buf =
+let[@inline always] unsafe_feed_32_be ?(off = 0) ~len:top sum buf =
   let buf32 = to_int32 ~off ~len:top buf in
   let len = ref top in
-  let sum = ref 0 in
+  let sum = ref sum in
   let i = ref 0 in
   while !len >= 4 do
     let v = int32_to_int (swap32 buf32.{!i}) in
@@ -89,20 +85,97 @@ let unsafe_digest_32_be ?(off = 0) ~len:top buf =
     sum := !sum + swap16 (unsafe_get_uint16 buf (off + (!i * 4)));
     len := !len - 2);
   if !len = 1 then sum := !sum + unsafe_get_uint8 buf (off + top - 1);
-  while !sum lsr 16 <> 0 do
-    sum := (!sum land 0xffff) + (!sum lsr 16)
+  !sum
+
+let[@inline always] finally sum =
+  let sum = ref sum in
+  let car = ref (!sum lsr 16) in
+  while !car != 0 do
+    sum := (!sum land 0xffff) + !car;
+    car := !sum lsr 16
   done;
   swap16 (lnot !sum land 0xffff)
 
+let[@inline always] unsafe_feed ~off ~len sum buf =
+  match Sys.word_size, Sys.big_endian with
+  | 64, false -> unsafe_feed_32_le ~off ~len sum buf
+  | 64, true -> unsafe_feed_32_be ~off ~len sum buf
+  | 32, false -> unsafe_feed_16_le ~off ~len sum buf
+  | n, be -> Fmt.invalid_arg "Unsupported platform (%d-bit, big-endian: %b)" n be
+
+let unsafe_digest ~off ~len buf =
+  let sum = (unsafe_feed[@inlined]) ~off ~len 0 buf in
+  (finally[@inlined]) sum
+
 let digest ?(off = 0) ?len buf =
   let len = match len with Some len -> len | None -> length buf - off in
-  match Sys.word_size, Sys.big_endian with
-  | 32, false -> unsafe_digest_16_le ~off ~len buf
-  | 64, false -> unsafe_digest_32_le ~off ~len buf
-  | 64, true -> unsafe_digest_32_be ~off ~len buf
-  | n, be ->
-    invalid_arg
-      ("don't know how to checksum on a " ^ string_of_int n ^ " bit " ^
-       (if be then "big-endian" else "little-endian") ^ " machine")
+  if len < 0
+  || off < 0
+  || off > length buf - len
+  then invalid_arg "Cheksum.digest";
+  unsafe_digest ~off ~len buf
 
-let digest_cstruct { Cstruct.buffer; off; len } = digest ~off ~len buffer
+let digest_cstruct { Cstruct.buffer; off; len } = unsafe_digest ~off ~len buffer
+let feed_cstruct sum { Cstruct.buffer; off; len } = unsafe_feed ~off ~len sum buffer
+
+external get_uint16_ne : string -> int -> int = "%caml_string_get16u"
+external get_uint8 : string -> int -> int = "%string_unsafe_get"
+
+let unsafe_feed_string_16_le ?(off = 0) ~len:top sum buf =
+  let len = ref top in
+  let sum = ref sum in
+  let i = ref 0 in
+  while !len >= 2 do
+    sum := !sum + get_uint16_ne buf (!i * 2);
+    incr i;
+    len := !len - 2
+  done;
+  if !len = 1 then sum := !sum + get_uint8 buf (off + top - 1);
+  !sum
+
+let unsafe_feed_string_16_be ?(off = 0) ~len:top sum buf =
+  let len = ref top in
+  let sum = ref sum in
+  let i = ref 0 in
+  while !len >= 2 do
+    sum := !sum + swap16 (get_uint16_ne buf (!i * 2));
+    incr i;
+    len := !len - 2
+  done;
+  if !len = 1 then sum := !sum + get_uint8 buf (off + top - 1);
+  !sum
+
+let feed_string ?(off= 0) ?len sum str =
+  let len = match len with
+    | Some len -> len
+    | None -> String.length str - off in
+  if off < 0
+  || len < 0
+  || off > String.length str - len
+  then invalid_arg "Checksum.digest_string";
+  if Sys.big_endian
+  then unsafe_feed_string_16_be ~off ~len sum str
+  else unsafe_feed_string_16_le ~off ~len sum str
+
+let digest_string ?(off= 0) ?len str =
+  let len = match len with
+    | Some len -> len
+    | None -> String.length str - off in
+  if off < 0
+  || len < 0
+  || off > String.length str - len
+  then invalid_arg "Checksum.digest_string";
+  let sum =
+    if Sys.big_endian
+    then unsafe_feed_string_16_be ~off ~len 0 str
+    else unsafe_feed_string_16_le ~off ~len 0 str in
+  finally sum
+
+let digest_strings sstr =
+  let fn = match Sys.big_endian with
+    | true -> fun sum str ->
+        unsafe_feed_string_16_be ~off:0 ~len:(String.length str) sum str
+    | false -> fun sum str ->
+        unsafe_feed_string_16_le ~off:0 ~len:(String.length str) sum str in
+  let sum = List.fold_left fn 0 sstr in
+  finally sum

--- a/src/checksum.ml
+++ b/src/checksum.ml
@@ -109,10 +109,8 @@ let unsafe_digest ~off ~len buf =
 
 let digest ?(off = 0) ?len buf =
   let len = match len with Some len -> len | None -> length buf - off in
-  if len < 0
-  || off < 0
-  || off > length buf - len
-  then invalid_arg "Cheksum.digest";
+  if len < 0 || off < 0 || off > length buf - len then
+    invalid_arg "Checksum.digest";
   unsafe_digest ~off ~len buf
 
 let digest_cstruct { Cstruct.buffer; off; len } = unsafe_digest ~off ~len buffer

--- a/src/checksum.ml
+++ b/src/checksum.ml
@@ -174,6 +174,7 @@ let digest_strings sstr =
     | true -> fun sum str ->
         unsafe_feed_string_16_be ~off:0 ~len:(String.length str) sum str
     | false -> fun sum str ->
-        unsafe_feed_string_16_le ~off:0 ~len:(String.length str) sum str in
+        unsafe_feed_string_16_le ~off:0 ~len:(String.length str) sum str
+  in
   let sum = List.fold_left fn 0 sstr in
   finally sum

--- a/src/checksum.mli
+++ b/src/checksum.mli
@@ -1,15 +1,15 @@
 type bigstring =
   (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
-val digest : ?off:int -> ?len:int -> bigstring -> int
+val digest : off:int -> len:int -> bigstring -> int
 val digest_cstruct : Cstruct.t -> int
 val feed_cstruct : int -> Cstruct.t -> int
-val feed_string : ?off:int -> ?len:int -> int -> string -> int
-val digest_string : ?off:int -> ?len:int -> string -> int
+val feed_string : off:int -> len:int -> int -> string -> int
+val digest_string : off:int -> len:int -> string -> int
 val digest_strings : string list -> int
 val finally : int -> int
 
 (**/*)
 
-val unsafe_feed_16_le : ?off:int -> len:int -> int -> bigstring -> int
-val unsafe_feed_32_le : ?off:int -> len:int -> int -> bigstring -> int
+val unsafe_feed_16_le : off:int -> len:int -> int -> bigstring -> int
+val unsafe_feed_32_le : off:int -> len:int -> int -> bigstring -> int

--- a/src/checksum.mli
+++ b/src/checksum.mli
@@ -1,8 +1,15 @@
 type bigstring =
   (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
-val unsafe_digest_16_le : ?off:int -> len:int -> bigstring -> int
-val unsafe_digest_32_le : ?off:int -> len:int -> bigstring -> int
-val unsafe_digest_32_be : ?off:int -> len:int -> bigstring -> int
 val digest : ?off:int -> ?len:int -> bigstring -> int
 val digest_cstruct : Cstruct.t -> int
+val feed_cstruct : int -> Cstruct.t -> int
+val feed_string : ?off:int -> ?len:int -> int -> string -> int
+val digest_string : ?off:int -> ?len:int -> string -> int
+val digest_strings : string list -> int
+val finally : int -> int
+
+(**/*)
+
+val unsafe_feed_16_le : ?off:int -> len:int -> int -> bigstring -> int
+val unsafe_feed_32_le : ?off:int -> len:int -> int -> bigstring -> int

--- a/src/segment.ml
+++ b/src/segment.ml
@@ -569,7 +569,7 @@ let checksum ~src ~dst cs =
       Bytes.blit_string (Ipaddr.V6.to_octets dst) 0 buf 16 16;
       Bytes.set_uint16_be buf 34 len;
       Bytes.set_uint8 buf 39 protocol;
-      let sum = Checksum.feed_string ~off:0 ~len:12 0 (Bytes.unsafe_to_string buf) in
+      let sum = Checksum.feed_string ~off:0 ~len:40 0 (Bytes.unsafe_to_string buf) in
       Cstruct.BE.set_uint16 cs 16 0;
       let sum = Checksum.feed_cstruct sum cs in
       Checksum.finally sum

--- a/src/segment.ml
+++ b/src/segment.ml
@@ -566,7 +566,7 @@ let checksum ~src ~dst cs =
   | Ipaddr.V6 src, Ipaddr.V6 dst ->
       let buf = Bytes.make 40 '\000' in
       Bytes.blit_string (Ipaddr.V6.to_octets src) 0 buf 0 16;
-      Bytes.blit_string (Ipaddr.V6.to_octets dst) 0 buf 16 32;
+      Bytes.blit_string (Ipaddr.V6.to_octets dst) 0 buf 16 16;
       Bytes.set_uint16_be buf 34 len;
       Bytes.set_uint8 buf 39 protocol;
       let sum = Checksum.feed_string ~off:0 ~len:12 0 (Bytes.unsafe_to_string buf) in

--- a/src/segment.ml
+++ b/src/segment.ml
@@ -548,34 +548,32 @@ let make_ack cb ~fin (src, src_port, dst, dst_port) =
     flag = if fin then Some `Fin else None ;
     push = false ; window ; options = [] ; payload = Cstruct.empty }
 
-let checksum ~src ~dst buf =
-  let plen = Cstruct.length buf in
+let checksum ~src ~dst cs =
+  let len = Cstruct.length cs in
+  let protocol = 0x06 in
   (* construct pseudoheader *)
-  let mybuf, off =
-    let protocol = 0x06 in
-    match src, dst with
-    | Ipaddr.V4 src, Ipaddr.V4 dst ->
-      let mybuf = Cstruct.create (12 + plen) in
-      Ipaddr_cstruct.V4.write_cstruct_exn src mybuf;
-      Ipaddr_cstruct.V4.write_cstruct_exn dst (Cstruct.shift mybuf 4);
-      Cstruct.set_uint8 mybuf 9 protocol;
-      Cstruct.BE.set_uint16 mybuf 10 plen;
-      mybuf, 12
-    | Ipaddr.V6 src, Ipaddr.V6 dst ->
-      let mybuf = Cstruct.create (40 + plen) in
-      Ipaddr_cstruct.V6.write_cstruct_exn src mybuf;
-      Ipaddr_cstruct.V6.write_cstruct_exn dst (Cstruct.shift mybuf 16);
-      Cstruct.BE.set_uint16 mybuf 34 plen;
-      Cstruct.set_uint8 mybuf 39 protocol;
-      mybuf, 40
-    | _ -> invalid_arg "mixing IPv4 and IPv6 addresses not supported"
-  in
-  (* blit tcp packet *)
-  Cstruct.blit buf 0 mybuf off plen;
-  (* ensure checksum to be 0 *)
-  Cstruct.BE.set_uint16 mybuf (off + 16) 0;
-  (* compute checksum *)
-  Checksum.digest_cstruct mybuf
+  match src, dst with
+  | Ipaddr.V4 src, Ipaddr.V4 dst ->
+      let buf = Bytes.make 12 '\000' in
+      Bytes.set_int32_be buf 0 (Ipaddr.V4.to_int32 src);
+      Bytes.set_int32_be buf 4 (Ipaddr.V4.to_int32 dst);
+      Bytes.set_uint8 buf 9 protocol;
+      Bytes.set_uint16_be buf 10 len;
+      let sum = Checksum.feed_string ~off:0 ~len:12 0 (Bytes.unsafe_to_string buf) in
+      Cstruct.BE.set_uint16 cs 16 0;
+      let sum = Checksum.feed_cstruct sum cs in
+      Checksum.finally sum
+  | Ipaddr.V6 src, Ipaddr.V6 dst ->
+      let buf = Bytes.make 40 '\000' in
+      Bytes.blit_string (Ipaddr.V6.to_octets src) 0 buf 0 16;
+      Bytes.blit_string (Ipaddr.V6.to_octets dst) 0 buf 16 32;
+      Bytes.set_uint16_be buf 34 len;
+      Bytes.set_uint8 buf 39 protocol;
+      let sum = Checksum.feed_string ~off:0 ~len:12 0 (Bytes.unsafe_to_string buf) in
+      Cstruct.BE.set_uint16 cs 16 0;
+      let sum = Checksum.feed_cstruct sum cs in
+      Checksum.finally sum
+  | _ -> invalid_arg "mixing IPv4 and IPv6 addresses not supported"
 
 let encode_into buf t =
   let opt_len = length_options t.options in


### PR DESCRIPTION
This PR adds few functions into the checksum module to be able to compute the checksum for bigstrings and strings.

Also, we can provide `feed` functions and a `finally` function which permits to calculate the checksum of a mix of bigstrings and strings. Then, this PR allocates a bytes instead of a cstruct.

I added a new benchmark which directly use `Segment.checksum`. This is my results:

```
+-------------+--------------+-----------------+
|             | with this PR | without this PR |
+-------------+--------------+-----------------+
|       1 run |      42.76ns |         92.56ns |
+-------------+--------------+-----------------+
```

So it's a win about micro-benchmarks. However, I did not notice a big change about macro-benchmark (`iperf3`). 