### PR TITLE
[WIP] Introduce the new TCP/IP stack for miou-solo5 (IPv4 only)

### DIFF
--- a/app/dune
+++ b/app/dune
@@ -1,6 +1,7 @@
 (executable
  (name server)
  (public_name server)
+ (package utcp)
  (modules server)
  (libraries utcp mirage-net-unix cstruct lwt logs ethernet arp.mirage
    tcpip.ipv4 mirage-crypto-rng.unix mirage-unix lwt.unix
@@ -10,6 +11,7 @@
 (executable
  (name single)
  (public_name single)
+ (package utcp)
  (modules single)
  (libraries utcp mirage-net-unix cstruct lwt logs ethernet arp.mirage
    mirage-crypto-rng.unix tcpip.ipv4 mirage-crypto-rng mirage-unix
@@ -20,6 +22,7 @@
 (executable
  (name pcap_replay)
  (public_name pcap)
+ (package utcp)
  (modules pcap_replay)
  (libraries utcp cstruct pcap-format ipaddr mtime logs ipaddr-cstruct cmdliner
    logs.fmt fmt.cli logs.cli fmt.tty)
@@ -28,6 +31,7 @@
 (executable
  (name trace_replay)
  (public_name trace)
+ (package utcp)
  (modules trace_replay)
  (libraries utcp base64 cstruct ipaddr mtime logs ipaddr-cstruct cmdliner
    logs.fmt fmt.cli logs.cli fmt.tty)

--- a/miou-solo5/arp_miou_solo5.ml
+++ b/miou-solo5/arp_miou_solo5.ml
@@ -1,0 +1,320 @@
+module Ethernet = Ethernet_miou_solo5
+
+[@@@warning "-37"]
+
+let error_msgf fmt = Fmt.kstr (fun msg -> Error (`Msg msg)) fmt
+
+module Packet = struct
+  type t =
+    { operation : operation
+    ; src_mac : Macaddr.t
+    ; dst_mac : Macaddr.t
+    ; src_ip : Ipaddr.V4.t
+    ; dst_ip : Ipaddr.V4.t }
+  and operation =
+    | Request | Reply
+
+  let operation_of_int = function
+    | 1 -> Ok Request
+    | 2 -> Ok Reply
+    | n -> error_msgf "Invalid ARPv4 operation (%02x)" n
+
+  let operation_to_int = function
+    | Request -> 1
+    | Reply -> 2
+
+  let guard err fn = if fn () then Ok () else Error err
+
+  let decode ?(off= 0) str =
+    let ( let* ) = Result.bind in
+    let* () = guard `Invalid_ARPv4_packet @@ fun () -> String.length str - off >= 28 in
+    let operation = String.get_uint16_be str (off + 6) in
+    let* operation = operation_of_int operation in
+    let src_mac = Macaddr.of_octets_exn (String.sub str (off + 8) 6) in
+    let src_ip = Ipaddr.V4.of_int32 (String.get_int32_be str (off + 14)) in
+    let dst_mac = Macaddr.of_octets_exn (String.sub str (off + 18) 6) in
+    let dst_ip = Ipaddr.V4.of_int32 (String.get_int32_be str (off + 24)) in
+    Ok { operation; src_mac; dst_mac; src_ip; dst_ip }
+
+  let unsafe_encode_into t ?(off= 0) bstr =
+    Bstr.set_uint16_be bstr (off + 0) 1;
+    Bstr.set_uint16_be bstr (off + 2) 0x0800;
+    Bstr.set_uint8 bstr (off + 4) 6;
+    Bstr.set_uint8 bstr (off + 5) 4;
+    Bstr.set_uint16_be bstr (off + 6) (operation_to_int t.operation);
+    let src_mac = Macaddr.to_octets t.src_mac in
+    Bstr.blit_from_string src_mac ~src_off:0 bstr ~dst_off:(off + 8) ~len:6;
+    Bstr.set_int32_be bstr (off + 14) (Ipaddr.V4.to_int32 t.src_ip);
+    let dst_mac = Macaddr.to_octets t.dst_mac in
+    Bstr.blit_from_string dst_mac ~src_off:0 bstr ~dst_off:(off + 18) ~len:6;
+    Bstr.set_int32_be bstr (off + 24) (Ipaddr.V4.to_int32 t.dst_ip);
+    28
+end
+
+let mac0 = Macaddr.of_octets_exn (String.make 6 '\000')
+
+type w = Macaddr.t Miou.Computation.t
+
+type entry =
+  | Static of Macaddr.t * bool
+  | Dynamic of Macaddr.t * int
+  | Pending of w * int
+
+type t =
+  { cache : (Ipaddr.V4.t, entry) Hashtbl.t
+  ; macaddr : Macaddr.t
+  ; ipaddr : Ipaddr.V4.t
+  ; timeout : int
+  ; retries : int
+  ; mutable epoch : int
+  ; src : Logs.src
+  ; eth : Ethernet.t
+  ; mutex : Miou.Mutex.t
+  ; condition : Miou.Condition.t
+  ; queue : string Ethernet.packet Queue.t }
+
+let alias t ipaddr =
+  let () = match Hashtbl.find t.cache ipaddr with
+    | exception Not_found -> ()
+    | Pending (c, _) -> ignore (Miou.Computation.try_return c t.macaddr)
+    | _ -> () in
+  Hashtbl.replace t.cache ipaddr (Static (t.macaddr, true));
+  let pkt =
+    { Packet.operation= Packet.Request
+    ; src_mac= t.macaddr
+    ; dst_mac= mac0
+    ; src_ip= ipaddr
+    ; dst_ip= ipaddr } in
+  (pkt, Macaddr.broadcast)
+
+let write t (arp, dst) =
+  (* NOTE(dinosaure): we already check, in [create] that the MTU is more than
+     [28] bytes. The buffer given by [Ethernet] is also more than [28] bytes. *)
+  let fn = Packet.unsafe_encode_into arp ~off:0 in
+  Ethernet.write_directly_into t.eth ~dst ~protocol:Ethernet.ARPv4 fn
+
+let guard err fn = if fn () then Ok () else Error err
+let macaddr t = t.macaddr
+
+let request t dst_ip =
+  let dst_mac = Macaddr.broadcast in
+  { Packet.operation= Request
+  ; src_mac= t.macaddr
+  ; dst_mac
+  ; src_ip= t.ipaddr
+  ; dst_ip }, dst_mac
+
+let reply arp macaddr =
+  let pkt =
+    { Packet.operation= Packet.Reply
+    ; src_mac= macaddr
+    ; dst_mac= arp.Packet.src_mac
+    ; src_ip= arp.Packet.dst_ip
+    ; dst_ip= arp.Packet.src_ip } in
+  pkt, arp.Packet.src_mac
+
+exception Timeout
+exception Clear
+
+let empty_bt = Printexc.get_callstack 0
+let timeout = (Timeout, empty_bt)
+let timeout c = ignore (Miou.Computation.try_cancel c timeout)
+let clear = (Clear, empty_bt)
+let clear c = ignore (Miou.Computation.try_cancel c clear)
+
+let tick t =
+  let epoch = t.epoch in
+  let fn k v (pkts, to_remove, timeouts) = match v with
+    | Dynamic (_, tick) when tick == epoch ->
+        pkts, (k :: to_remove), timeouts
+    | Dynamic (_, tick) when tick == epoch + 1 ->
+        request t k :: pkts, to_remove, timeouts
+    | Pending (w, retry) when retry == epoch ->
+        pkts, k :: to_remove, w :: timeouts
+    | Pending _ ->
+        request t k :: pkts, to_remove, timeouts
+    | _ -> pkts, to_remove, timeouts in
+  let outs, to_remove, timeouts = Hashtbl.fold fn t.cache ([], [], []) in
+  List.iter (Hashtbl.remove t.cache) to_remove;
+  List.iter (write t) outs;
+  List.iter timeout timeouts;
+  t.epoch <- t.epoch + 1
+
+let handle_request t arp =
+  let dst = arp.Packet.dst_ip in
+  let src = arp.Packet.src_ip in
+  let src_mac = arp.Packet.src_mac in
+  Logs.debug ~src:t.src (fun m -> m "%a:%a: who has %a?"
+    Macaddr.pp src_mac Ipaddr.V4.pp src Ipaddr.V4.pp dst);
+  match Hashtbl.find t.cache dst with
+  | exception Not_found -> ()
+  | Static (macaddr, true) ->
+      write t (reply arp macaddr)
+  | _ -> ()
+
+let handle_reply t src macaddr =
+  let entry = Dynamic (macaddr, t.epoch + t.timeout) in
+  Logs.debug ~src:t.src (fun m -> m "handle ARPv4 reply packet from %a:%a"
+    Macaddr.pp macaddr Ipaddr.V4.pp src);
+  match Hashtbl.find t.cache src with
+  | exception Not_found -> ()
+  | Static (_, adv) ->
+      if adv && Macaddr.compare macaddr mac0 == 0
+      then Logs.debug ~src:t.src (fun m -> m "ignoring gratuitious ARP from %a using %a"
+        Macaddr.pp macaddr Ipaddr.V4.pp src)
+  | Dynamic (macaddr', _) ->
+      if Macaddr.compare macaddr macaddr' != 0
+      then Logs.debug ~src:t.src (fun m -> m "set %a from %a to %a"
+        Ipaddr.V4.pp src Macaddr.pp macaddr' Macaddr.pp macaddr);
+      Hashtbl.replace t.cache src entry
+  | Pending (c, _) ->
+      Logs.debug ~src:t.src (fun m -> m "%a is-at %a"
+        Ipaddr.V4.pp src Macaddr.pp macaddr);
+      ignore (Miou.Computation.try_return c macaddr);
+      Hashtbl.replace t.cache src entry
+
+let input t pkt =
+  match Packet.decode pkt.Ethernet.payload with
+  | Error _ ->
+      Logs.err ~src:t.src (fun m -> m "Invalid ARPv4 packet:");
+      Logs.err ~src:t.src (fun m -> m "@[<hov>%a@]" (Hxd_string.pp Hxd.default)
+        pkt.Ethernet.payload)
+  | Ok arp ->
+      if Ipaddr.V4.compare arp.Packet.src_ip arp.Packet.dst_ip == 0
+      || arp.Packet.operation == Packet.Reply
+      then
+        let mac = arp.Packet.src_mac
+        and src = arp.Packet.src_ip in
+        handle_reply t src mac
+      else handle_request t arp
+
+let to_error (exn, _bt) = match exn with
+  | Timeout -> `Timeout
+  | Clear -> `Clear
+  | exn -> `Exn exn
+
+type error =
+  [ `Timeout
+  | `Clear
+  | `Exn of exn ]
+
+let pp_error ppf = function
+  | `Timeout -> Fmt.string ppf "Timeout"
+  | `Clear -> Fmt.string ppf "ARP table reset"
+  | `Exn exn -> Fmt.pf ppf "Unexpected exception: %s" (Printexc.to_string exn)
+
+let query t ipaddr =
+  match Hashtbl.find t.cache ipaddr with
+  | exception Not_found ->
+      let w = Miou.Computation.create () in
+      let pending = Pending (w, t.epoch + t.retries) in
+      Hashtbl.replace t.cache ipaddr pending;
+      write t (request t ipaddr);
+      Miou.Computation.await w
+      |> Result.map_error to_error
+  | Pending (w, _) ->
+      Miou.Computation.await w
+      |> Result.map_error to_error
+  | Static (macaddr, _)
+  | Dynamic (macaddr, _) -> Ok macaddr
+
+let ips t =
+  let fn k v acc = match v with
+    | Static (_, true) -> k :: acc
+    | _ -> acc in
+  Hashtbl.fold fn t.cache []
+
+let add_ip t ipaddr =
+  match ips t with
+  | [] ->
+      Hashtbl.iter (fun _ -> function
+        | Pending (w, _) -> clear w
+        | _ -> ()) t.cache;
+      Hashtbl.clear t.cache;
+      write t (alias t ipaddr)
+  | _ ->
+      write t (alias t ipaddr)
+
+let set_ips t = function
+  | [] ->
+      Hashtbl.iter (fun _ -> function
+        | Pending (w, _) -> clear w
+        | _ -> ()) t.cache;
+      Hashtbl.clear t.cache
+  | ipaddr :: rest ->
+      Hashtbl.iter (fun _ -> function
+        | Pending (w, _) -> clear w
+        | _ -> ()) t.cache;
+      Hashtbl.clear t.cache;
+      write t (alias t ipaddr);
+      List.iter (add_ip t) rest
+
+type daemon = unit Miou.t
+
+type event =
+  | In of string Ethernet.packet Queue.t
+  | Tick
+
+let read_or_sync ?(delay= 1_500_000_000) t =
+  let prm1 = Miou.async @@ fun () ->
+    Miou.Mutex.protect t.mutex @@ fun () ->
+    if Queue.is_empty t.queue
+    then Miou.Condition.wait t.condition t.mutex;
+    let todo = Queue.create () in
+    Queue.transfer t.queue todo; In todo in
+  let prm0 = Miou.async @@ fun () ->
+    Miou_solo5.sleep delay;
+    Tick in
+  match Miou.await_first [ prm0; prm1 ] with
+  | Ok value -> value
+  | Error exn ->
+      Logs.err ~src:t.src (fun m -> m "Unexpected exception: %s"
+        (Printexc.to_string exn));
+      In (Queue.create ())
+
+let arp ?(delay= 1_500_000_000) t =
+  let rec go rem =
+    let t0 = Miou_solo5.clock_monotonic () in
+    match read_or_sync ~delay:rem t with
+    | In queue ->
+      let fn = input t in
+      Queue.iter fn queue;
+      let t1 = Miou_solo5.clock_monotonic () in
+      let rem = rem - (t1 - t0) in
+      let rem = if rem <= 0 then delay else rem in
+      go rem
+    | Tick -> tick t; go delay in
+  go delay
+
+let create ?(delay= 1_500_000_000) ?(timeout= 800) ?(retries= 5) ?src ?ipaddr eth =
+  let ( let* ) = Result.bind in
+  let macaddr = Ethernet.macaddr eth in
+  (* enough for ARP packets *)
+  let* () = guard `MTU_too_small @@ fun () -> Ethernet.mtu eth >= 28 in
+  let src = match src with
+    | None -> Logs.Src.create (Fmt.str "%a" Macaddr.pp macaddr)
+    | Some src -> src in
+  if timeout <= 0
+  then Fmt.invalid_arg "Arp_miou_solo5.create: null or negative timeout";
+  if retries < 0
+  then Fmt.invalid_arg "Arg_miou_solo5.create: negative retries value";
+  let unknown = Option.is_none ipaddr in
+  let ipaddr = Option.value ~default:Ipaddr.V4.any ipaddr in
+  let cache = Hashtbl.create 0x10 in
+  let t = { cache; macaddr; ipaddr; timeout; retries; epoch= 0; src; eth
+          ; mutex= Miou.Mutex.create ()
+          ; condition= Miou.Condition.create ()
+          ; queue= Queue.create () } in
+  if unknown == false
+  then write t (alias t ipaddr);
+  let prm = Miou.async (fun () -> arp ~delay t) in
+  Ok (prm, t)
+
+let transfer t pkt =
+  let payload = Slice_bstr.sub_string pkt.Ethernet.payload ~off:0 ~len:28 in
+  let pkt = { pkt with Ethernet.payload } in
+  Miou.Mutex.protect t.mutex @@ fun () ->
+  Queue.push pkt t.queue;
+  Miou.Condition.signal t.condition
+
+let kill = Miou.cancel

--- a/miou-solo5/arp_miou_solo5.mli
+++ b/miou-solo5/arp_miou_solo5.mli
@@ -1,0 +1,29 @@
+module Ethernet = Ethernet_miou_solo5
+
+type error =
+  [ `Exn of exn
+  | `Timeout
+  | `Clear ]
+
+val pp_error : error Fmt.t
+
+type t
+type daemon
+
+val create :
+     ?delay:int
+  -> ?timeout:int
+  -> ?retries:int
+  -> ?src:Logs.Src.t
+  -> ?ipaddr:Ipaddr.V4.t
+  -> Ethernet.t
+  -> (daemon * t, [> `MTU_too_small ]) result
+
+val macaddr : t -> Macaddr.t
+val set_ips : t -> Ipaddr.V4.t list -> unit
+val query : t -> Ipaddr.V4.t -> (Macaddr.t, [> error ]) result
+
+(** ARPv4 daemon *)
+
+val transfer : t -> Slice_bstr.t Ethernet.packet -> unit
+val kill : daemon -> unit

--- a/miou-solo5/diet.ml
+++ b/miou-solo5/diet.ml
@@ -1,0 +1,143 @@
+type t =
+  | Empty
+  | Node of node
+and node =
+  { x : int
+  ; y : int
+  ; l : t
+  ; r : t
+  ; h : int }
+
+let height = function
+  | Empty -> 0
+  | Node n -> n.h
+
+let empty = Empty
+
+let is_empty = function
+  | Empty -> true
+  | _ -> false
+
+let rec node x y l r =
+  let hl = height l and hr = height r in
+  if hl > hr + 2
+  then
+    let[@warning "-8"] Node { x= lx; y= ly; l= ll; r= lr; _ } = l in
+    if height ll >= height lr
+    then node lx ly ll (node x y lr r)
+    else
+      let[@warning "-8"] Node { x= lrx; y= lry; l= lrl; r= lrr; _ } = lr in
+      node lrx lry (node lx ly ll lrl) (node x y lrr r)
+  else if hr > hl + 2
+  then
+    let[@warning "-8"] Node { x= rx; y= ry; l= rl; r= rr; _ } = r in
+    if height rr >= height rl
+    then node rx ry (node x y l rl) rr
+    else
+      let[@warning "-8"] Node { x= rlx; y= rly; l= rll; r= rlr; _ } = rl in
+      node rlx rly (node x y l rll) (node rx ry rlr rr)
+  else
+    let h = Int.max (height l) (height r) + 1 in
+    Node { x; y; l; r; h }
+
+let rec split_max = function
+  | { x; y; l; r= Empty; _ } -> x, y, l
+  | { r= Node r; _ } as n ->
+      let u, v, r' = split_max r in
+      u, v, node n.x n.y n.l r'
+
+(*
+let rec split_min = function
+  | { x; y; l= Empty; r; _ } -> x, y, r
+  | { l= Node l; _ } as n ->
+      let u, v, l' = split_min l in
+      u, v, node n.x n.y l' n.r
+
+let add_left = function
+  | { l= Empty; _ } as n -> n
+  | { l= Node l; _ } as n ->
+      let x', y', l' = split_max l in
+      if y' + 1 == n.x
+      then { n with x= x'; l= l' }
+      else n
+
+let add_right = function
+  | { r= Empty; _ } as n -> n
+  | { r= Node r; _ } as n ->
+      let x', y', r' = split_min r in
+      if n.y + 1 == x'
+      then { n with y= y'; r= r' }
+      else n
+*)
+
+exception Overlap
+
+let () = Printexc.register_printer @@ function
+  | Overlap -> Some "Fragment overlap"
+  | _ -> None
+
+let rec add (x, y) t =
+  match t with
+  | Empty -> node x y Empty Empty
+  | Node n when y < n.x ->
+      let l = add (x, y) n.l in
+      node n.x n.y l n.r
+  | Node n when n.y < x ->
+      let r = add (x, y) n.r in
+      node n.x n.y n.l r
+  | _ -> raise_notrace Overlap
+
+let add ~off ~len t =
+  let x = off and y = off + len - 1 in
+  add (x, y) t
+
+let merge l r = match l, r with
+  | l, Empty -> l
+  | Empty, r -> r
+  | Node l, r ->
+      let x, y, l' = split_max l in
+      node x y l' r
+
+let rec remove (x, y) t =
+  match t with
+  | Empty -> Empty
+  (* completely to the left *)
+  | Node n when y < n.x ->
+      let l = remove (x, y) n.l in
+      node n.x n.y l n.r
+  (* completely to the right *)
+  | Node n when n.y < x ->
+      let r = remove (x, y) n.r in
+      node n.x n.y n.l r
+  (* overlap on the left only *)
+  | Node n when x < n.x && y < n.y ->
+      let n' = node (y+1) n.y n.l n.r in
+      remove (x, n.x-1) n'
+  (* overlap on the right only *)
+  | Node n when y > n.y && x > n.x ->
+      let n' = node n.x (x-1) n.l n.r in
+      remove (n.y+1, y) n'
+  (* overlap on both side *)
+  | Node n when x <= n.x && y >= n.y ->
+      let l = remove (x, n.x) n.l in
+      let r = remove (n.y, y) n.r in
+      merge l r
+  (* completely within *)
+  | Node n when y == n.y ->
+      node n.x (x-1) n.l n.r
+  | Node n when x == n.x ->
+      node (y+1) n.y n.l n.r
+  | Node n ->
+      assert (n.x <= x-1);
+      assert (y+1 <= n.y);
+      let r = node (y+1) n.y Empty n.r in
+      node n.x (x-1) n.l r
+
+let rec fold fn t acc = match t with
+  | Empty -> acc
+  | Node n ->
+      let acc = fold fn n.l acc in
+      let acc = fn (n.x, n.y) acc in
+      fold fn n.r acc
+
+let diff a b = fold remove a b

--- a/miou-solo5/diet.mli
+++ b/miou-solo5/diet.mli
@@ -1,0 +1,6 @@
+type t
+
+val empty : t
+val add : off:int -> len:int -> t -> t
+val diff : t -> t -> t
+val is_empty : t -> bool

--- a/miou-solo5/dune
+++ b/miou-solo5/dune
@@ -1,0 +1,5 @@
+(library
+ (name utcp_miou_solo5)
+ (public_name utcp-miou-solo5)
+ (flags (:standard -dlambda -dump-into-file))
+ (libraries lru mirage-crypto-rng utcp duration hxd.core hxd.string fmt ipaddr macaddr bin slice.bstr miou-solo5))

--- a/miou-solo5/ethernet_miou_solo5.ml
+++ b/miou-solo5/ethernet_miou_solo5.ml
@@ -1,0 +1,147 @@
+[@@@warning "-30"]
+
+module Packet = struct
+  type protocol =
+    | ARPv4
+    | IPv4
+    | IPv6
+
+  type t =
+    { src : Macaddr.t
+    ; dst : Macaddr.t
+    ; protocol : protocol option }
+
+  let guard err fn = if fn () then Ok () else Error err
+
+  let protocol_of_int = function
+    | 0x0806 -> Some ARPv4
+    | 0x0800 -> Some IPv4
+    | 0x86dd -> Some IPv6
+    | _ -> None
+
+  let protocol_to_int = function
+    | ARPv4 -> 0x0806
+    | IPv4 -> 0x0800
+    | IPv6 -> 0x86dd
+
+  let decode bstr ~len =
+    let ( let* ) = Result.bind in
+    let* () = guard `Invalid_ethernet_packet @@ fun () ->
+      len >= 14 in
+    let dst = Macaddr.of_octets_exn (Bstr.sub_string bstr ~off:0 ~len:6) in
+    let src = Macaddr.of_octets_exn (Bstr.sub_string bstr ~off:6 ~len:6) in
+    let protocol = Bstr.get_uint16_be bstr 12 in
+    let protocol = protocol_of_int protocol in
+    let payload = Slice_bstr.make ~off:14 ~len:(len - 14) bstr in
+    Ok ({ src; dst; protocol }, payload)
+
+  let encode_into t ?(off= 0) bstr = match t.protocol with
+    | None -> Fmt.invalid_arg "Ethernet.Packet.encode_into: you must specify a protocol"
+    | Some protocol ->
+        let protocol = protocol_to_int protocol in
+        Bstr.blit_from_string (Macaddr.to_octets t.dst) ~src_off:0 bstr ~dst_off:(off + 0) ~len:6;
+        Bstr.blit_from_string (Macaddr.to_octets t.src) ~src_off:0 bstr ~dst_off:(off + 6) ~len:6;
+        Bstr.set_uint16_be bstr 12 protocol
+end
+
+type protocol = Packet.protocol =
+  | ARPv4
+  | IPv4
+  | IPv6
+
+type t =
+  { net : Miou_solo5.Net.t
+  ; mutable handler : handler
+  ; mtu : int
+  ; mac : Macaddr.t
+  ; src : Logs.src
+  ; bstr_ic : Bstr.t
+  ; bstr_oc : Bstr.t }
+and 'a packet =
+  { src : Macaddr.t option
+  ; dst : Macaddr.t
+  ; protocol : Packet.protocol
+  ; payload : 'a }
+and handler = Slice_bstr.t packet -> unit
+
+let mac { mac; _ } = mac
+
+let write_directly_into t (packet : (Bstr.t -> int) packet) =
+  let fn = packet.payload in
+  let src = Option.value ~default:t.mac packet.src in
+  let pkt = { Packet.src; dst= packet.dst; protocol= Some packet.protocol } in
+  Packet.encode_into pkt ~off:0 t.bstr_oc;
+  let bstr = Bstr.sub t.bstr_oc ~off:14 ~len:(Bstr.length t.bstr_oc - 14) in
+  let plus = fn bstr in
+  Logs.debug ~src:t.src (fun m -> m "write ethernet packet src:%a -> dst:%a (%d byte(s))"
+    Macaddr.pp src Macaddr.pp packet.dst plus);
+  Logs.debug ~src:t.src (fun m -> m "@[<hov>%a@]"
+    (Hxd_string.pp Hxd.default) (Bstr.sub_string t.bstr_oc ~off:0 ~len:(14 + plus)));
+  Miou_solo5.Net.write_bigstring t.net ~off:0 ~len:(14 + plus) t.bstr_oc
+
+let rec daemon t =
+  let len = Miou_solo5.Net.read_bigstring t.net t.bstr_ic in
+  begin match Packet.decode t.bstr_ic ~len with
+  | Error _ ->
+    let str = Bstr.sub_string t.bstr_ic ~off:0 ~len in
+    Logs.err ~src:t.src (fun m -> m "Invalid Ethernet packet");
+    Logs.err ~src:t.src (fun m -> m "@[<hov>%a@]" (Hxd_string.pp Hxd.default) str)
+  | Ok ({ Packet.protocol= Some protocol; src; dst }, payload) ->
+    let packet =
+      { src= Some src; dst; protocol; payload } in
+    if Macaddr.compare dst t.mac == 0
+    || Macaddr.is_unicast dst == false
+    then
+      try t.handler packet
+      with exn ->
+        Logs.err ~src:t.src (fun m -> m "Unexpected exception from the user's handler: %s"
+          (Printexc.to_string exn));
+    else begin
+      let payload = Slice_bstr.to_string payload in
+      Logs.debug ~src:t.src (fun m -> m "Ignore (%a -> %a):" Macaddr.pp src Macaddr.pp dst);
+      Logs.debug ~src:t.src (fun m -> m "@[<hov>%a@]" (Hxd_string.pp Hxd.default) payload);
+    end
+  | Ok _ -> () end;
+  daemon t
+
+let write_directly_into t ?src ~dst ~protocol fn =
+  let pkt = { src; dst; protocol; payload= fn } in
+  write_directly_into t pkt
+
+let guard err fn = if fn () then Ok () else Error err
+
+type daemon = unit Miou.t
+
+let create ?(mtu= 1500) ?(handler= ignore) mac net =
+  let ( let* ) = Result.bind in
+  let* () = guard `MTU_too_small @@ fun () -> mtu > 14 in (* enough for Ethernet packets *)
+  let bstr_ic = Bstr.create (14 + mtu) in
+  let bstr_oc = Bstr.create (14 + mtu) in
+  (* NOTE(dinosaure): the first [Bstr.sub] does a [malloc()], then any
+     [Bstr.sub] are cheap. We should use [Slice] instead of [Bstr]. TODO! *)
+  let bstr_ic = Bstr.sub bstr_ic ~off:0 ~len:(14 + mtu) in
+  let bstr_oc = Bstr.sub bstr_oc ~off:0 ~len:(14 + mtu) in
+  let src = Logs.Src.create (Macaddr.to_string mac) in
+  let t =
+    { net
+    ; handler
+    ; mtu
+    ; mac
+    ; src
+    ; bstr_ic
+    ; bstr_oc } in
+  let daemon = Miou.async @@ fun () -> daemon t in
+  Ok (daemon, t)
+
+let _cnt = Atomic.make 0
+
+let mtu { mtu; _ } = mtu
+let macaddr { mac; _ } = mac
+
+let set_handler t handler =
+  Atomic.incr _cnt;
+  t.handler <- handler;
+  if Atomic.get _cnt > 1
+  then Logs.warn ~src:t.src (fun m -> m "Ethernet handler modified more than once")
+
+let kill = Miou.cancel

--- a/miou-solo5/ethernet_miou_solo5.mli
+++ b/miou-solo5/ethernet_miou_solo5.mli
@@ -1,0 +1,41 @@
+type t
+type daemon
+
+val mac : t -> Macaddr.t
+
+type protocol =
+  | ARPv4
+  | IPv4
+  | IPv6
+
+type 'a packet =
+  { src : Macaddr.t option
+  ; dst : Macaddr.t
+  ; protocol : protocol
+  ; payload : 'a }
+
+type handler = Slice_bstr.t packet -> unit
+
+val write_directly_into :
+     t
+  -> ?src:Macaddr.t
+  -> dst:Macaddr.t
+  -> protocol:protocol
+  -> (Bstr.t -> int)
+  -> unit
+
+val create :
+     ?mtu:int
+  -> ?handler:(Slice_bstr.t packet -> unit)
+  -> Macaddr.t
+  -> Miou_solo5.Net.t
+  -> (daemon * t, [> `MTU_too_small ]) result
+(** NOTE(dinosaure): Note that the handler managing the Ethernet frames does not
+    run cooperatively but from the main task that manages all the I/O. In other
+    words, it is not possible to write a new frame from the [handler]. This must
+    be done "outside" (in another task), otherwise a deadlock may occur. *)
+
+val kill : daemon -> unit
+val mtu : t -> int
+val macaddr : t -> Macaddr.t
+val set_handler : t -> handler -> unit

--- a/miou-solo5/fragment.ml
+++ b/miou-solo5/fragment.ml
@@ -1,0 +1,115 @@
+let src = Logs.Src.create "fragment"
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+type t =
+  | Unsized : Ropes.unknown Ropes.t -> t
+  | Sized : Diet.t * bytes -> t
+
+(* A payload can be:
+   - an entire packet (Unfragmented)
+   - the start of a fragment whose end is unknown (Unsized)
+   - a packet that has not yet been fully received (but which size is known) (Sized)
+
+   In the case of a fragment whose size is unknown, a Rope is used so that
+   insertion at random locations is not costly. This Rope is in a state where we
+   do not know the final size ([Ropes.unknown]). We can therefore add fragments
+   one after the other "ad infinitum". However, we cannot add a fragment on top
+   of another existing one. If this is the case, the addition raises the
+   [Overlap] exception.
+
+   Then, if we know the last fragment, we know the final size of our packet. We
+   can therefore [Ropes.fixed] our ropes. This consists of creating a final buffer
+   in which we will copy all our fragments (a reassembly, in short). However,
+   this does not mean that we have received the whole of our package; there may
+   be holes.
+
+   It is therefore always necessary to check that the addition of new fragments
+   to this buffer does not overlap other already existing fragments. For this
+   reason, we associate with this buffer a Discrete Interval Encoding Tree that
+   contains all the intervals already "filled" in our buffer. A [Sized] value is
+   then created.
+
+   Thanks to the DIET, we can verify that the addition of all these intervals
+   forms a continuous final interval of our packet in its entirety. All we have
+   to do is make a [Diet.diff] between our current DIET and the one that
+   contains this final interval. If the result is empty, it means that our
+   current DIET contains all the intervals necessary to complete our buffer. Our
+   packet is complete!
+
+   Finally, there is the special case of an unfragmented packet. This
+   corresponds to our "happy path" where the bigstring used physically
+   corresponds to the one used (and filled) by Solo5. That is to say that from
+   Solo5 up to here, this unfragmented packet **is not** a copy.
+*)
+
+let singleton ~off ?(limit= false) slice : t =
+  match off, limit with
+  | _, false ->
+    let str = Slice_bstr.to_string slice in
+    let empty = Ropes.(Unknown Limitless) in
+    let ropes = Ropes.insert ~off str empty in
+    Log.debug (fun m -> m "+%d byte(s) %@ %d" (String.length str) off);
+    Unsized ropes
+  | 0, true -> invalid_arg "Unfragmented packet"
+  | _, true ->
+    let str = Slice_bstr.to_string slice in
+    let empty = Ropes.(Unknown Limitless) in
+    let ropes = Ropes.insert ~off str empty in
+    let max = off + String.length str in
+    Log.debug (fun m -> m "+%d byte(s) %@ %d (max: %d)" (String.length str) off max);
+    let ropes = Ropes.fixed ~max ropes in
+    let diet, buf = Ropes.to_bytes ropes in
+    Sized (diet, buf)
+
+let weight = function
+  | Unsized ropes -> Ropes.weight ropes
+  | Sized (_, buf) -> Bytes.length buf
+
+exception Out_of_bounds
+exception Overlap
+exception Too_big
+
+let () = Printexc.register_printer @@ function
+  | Out_of_bounds -> Some "Fragment out of bounds"
+  | Overlap -> Some "Fragment overlap"
+  | Too_big -> Some "Too big"
+  | _ -> None
+
+let insert t ~off ?(limit= false) str =
+  match t, limit with
+  | Sized (diet, buf), false ->
+      let len = String.length str in
+      if off < 0
+      || off > Bytes.length buf - len
+      then raise_notrace Out_of_bounds;
+      begin try
+        let diet = Diet.add ~off ~len diet in
+        Bytes.unsafe_blit_string str 0 buf off len;
+        Sized (diet, buf)
+      with _ -> raise_notrace Overlap end
+  | Unsized ropes, false ->
+      Log.debug (fun m -> m "+%d byte(s) %@ %d" (String.length str) off);
+      let ropes = Ropes.insert ~off str ropes in
+      (* NOTE(dinosaure): actually, we  can increase the ropes without limit.
+         This is also the case with [mirage-tcpip], which has no mechanism to
+         limit the [payload]. Not sure if you should put a limit or not. *)
+      Unsized ropes
+  | Sized _, true -> failwith "Multiple MF:0 fragments"
+  | Unsized ropes, true ->
+      let max = off + String.length str in
+      Log.debug (fun m -> m "+%d byte(s) %@ %d (max: %d)" (String.length str) off max);
+      let ropes = Ropes.insert ~off str ropes in
+      let ropes = Ropes.fixed ~max ropes in
+      let diet, buf = Ropes.to_bytes ropes in
+      Sized (diet, buf)
+
+let is_complete : t -> bool = function
+  | Unsized _ -> false
+  | Sized (diet, buf) ->
+      let buf = Diet.add ~off:0 ~len:(Bytes.length buf) Diet.empty in
+      Diet.(is_empty (diff diet buf))
+
+let reassemble_exn = function
+  | Unsized _ -> invalid_arg "Fragment.reassemble_exn"
+  | Sized (_, buf) -> Bytes.unsafe_to_string buf

--- a/miou-solo5/icmpv4_miou_solo5.ml
+++ b/miou-solo5/icmpv4_miou_solo5.ml
@@ -1,0 +1,202 @@
+let src = Logs.Src.create "icmpv4"
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+module Packet = struct
+  type 'a t =
+    { code : int
+    ; kind : 'a kind
+    ; checksum : int
+    ; shdr : 'a }
+  and 'a kind =
+    | Echo_reply : id_and_seq kind
+    | Destination_unreachable : next_hop_mtu kind
+    | Source_quench : unused kind
+    | Redirect : Ipaddr.V4.t kind
+    | Echo_request : id_and_seq kind
+    | Time_exceeded : unused kind
+    | Parameter_problem : pointer kind
+    | Timestamp_request : id_and_seq kind
+    | Timestamp_reply : id_and_seq kind
+    | Information_request : id_and_seq kind
+    | Information_reply : id_and_seq kind
+  and id_and_seq = int * int
+  and next_hop_mtu = Hop of int [@@unboxed]
+  and pointer = Pointer of int [@@unboxed]
+  and unused = Unused
+  and pack = Kind : 'a kind -> pack
+  and packet = Packet : 'a t -> packet
+
+  open Bin
+
+  let kind =
+    let f = function
+      | 0 -> Kind Echo_reply
+      | 3 -> Kind Destination_unreachable
+      | 4 -> Kind Source_quench
+      | 5 -> Kind Redirect
+      | 8 -> Kind Echo_request
+      | 11 -> Kind Time_exceeded
+      | 12 -> Kind Parameter_problem
+      | 13 -> Kind Timestamp_request
+      | 14 -> Kind Timestamp_reply
+      | 15 -> Kind Information_request
+      | 16 -> Kind Information_reply
+      | _ -> invalid_arg "Invalid ICMPv4 message" in
+    let g = function
+      | Kind Echo_reply -> 0
+      | Kind Destination_unreachable -> 3
+      | Kind Source_quench -> 4
+      | Kind Redirect -> 5
+      | Kind Echo_request -> 8
+      | Kind Time_exceeded -> 11
+      | Kind Parameter_problem -> 12
+      | Kind Timestamp_request -> 13
+      | Kind Timestamp_reply -> 14
+      | Kind Information_request -> 15
+      | Kind Information_reply -> 16 in
+    map uint8 f g
+
+  let unused = const Unused
+  let ipaddr = map beint32 Ipaddr.V4.of_int32 Ipaddr.V4.to_int32
+
+  let id_and_seq =
+    record (fun id seq -> (id, seq))
+    |+ field beuint16 fst
+    |+ field beuint16 snd
+    |> sealr
+
+  let next_hop_mtu =
+    let f arr = Hop arr.(1) in
+    let g (Hop mtu) = [| 0; mtu |] in
+    map (seq ~len:2 beuint16) f g
+
+  let pointer =
+    let f byte = Pointer byte in
+    let g (Pointer byte) = byte in
+    map uint8 f g
+
+  let shdr : type a. a kind -> a Bin.t = function
+    | Echo_request -> id_and_seq
+    | Echo_reply -> id_and_seq
+    | Timestamp_request -> id_and_seq
+    | Timestamp_reply -> id_and_seq
+    | Information_request -> id_and_seq
+    | Information_reply -> id_and_seq
+    | Destination_unreachable -> next_hop_mtu
+    | Time_exceeded -> unused
+    | Source_quench -> unused
+    | Redirect -> ipaddr
+    | Parameter_problem -> pointer
+
+  let t ~kind:knd =
+    let fn _knd code checksum shdr =
+      { kind= knd; code; checksum; shdr } in
+    record fn
+    |+ field kind (Fun.const (Kind knd))
+    |+ field uint8 (fun t -> t.code)
+    |+ field beuint16 (fun t -> t.checksum)
+    |+ field (shdr knd) (fun t -> t.shdr)
+    |> sealr
+
+  let decode ?(off= 0) str =
+    let pos = off in
+    let Kind kind = decode kind str (ref off) in
+    let off = ref off in
+    let pkt = decode (t ~kind) str off in
+    (* TODO(dinosaure): can we avoid this copy? *)
+    let buf = Bytes.of_string str in
+    let len = String.length str in
+    Bytes.set_uint16_be buf (pos + 2) 0;
+    let chk = Utcp.Checksum.digest_string ~off:pos ~len (Bytes.unsafe_to_string buf) in
+    Log.debug (fun m -> m "checksum: %04x, has: %04x" pkt.checksum chk);
+    if pkt.checksum != chk
+    then invalid_arg "Invalid ICMPv4 checksum";
+    let payload = String.sub str !off (String.length str - !off) in
+    Packet pkt, payload
+
+  let decode ?off bstr =
+    try Ok (decode ?off bstr)
+    with exn ->
+      Log.err (fun m -> m "Got an exception while decoding ICMPv4 packet: %s"
+        (Printexc.to_string exn));
+      Error `Invalid_ICMPv4_packet
+
+  let to_bytes pkt =
+    Bin.to_string (t ~kind:pkt.kind) pkt
+    |> Bytes.unsafe_of_string
+end
+
+module IPv4 = Ipv4_miou_solo5
+
+let input ipv4 pkt payload =
+  let dst = pkt.IPv4.src in
+  match Packet.decode payload with
+  | Error _ ->
+      Logs.err (fun m -> m "Invalid ICMPv4 packet:");
+      Logs.err (fun m -> m "@[<hov>%a@]" (Hxd_string.pp Hxd.default) payload)
+  | Ok (Packet pkt, payload) ->
+      begin match pkt.kind with
+      | Packet.Echo_request ->
+          let pkt = { Packet.code= 0; kind= Echo_reply; checksum= 0; shdr= pkt.shdr } in
+          let buf = Packet.to_bytes pkt in
+          let chk = Utcp.Checksum.digest_strings [ Bytes.unsafe_to_string buf; payload ] in
+          Bytes.set_uint16_be buf 2 chk;
+          let pkt = Bytes.unsafe_to_string buf in
+          let pkt = IPv4.Writer.of_strings ipv4 [ pkt; payload ] in
+          let result = IPv4.write ipv4 dst ~protocol:1 pkt in
+          let err _ =
+            Log.err (fun m -> m "Impossible to send ICMPv4 echo-reply packet") in
+          let _ = Result.map_error err result in ()
+      | _ ->
+          Log.debug (fun m -> m "Ignore ICMPv4 packet") end
+
+type t =
+  { mutex : Miou.Mutex.t
+  ; condition : Miou.Condition.t
+  ; queue : (IPv4.packet * string) Queue.t
+  ; ipv4 : IPv4.t
+  ; orphans : unit Miou.orphans }
+
+let rec clean orphans =
+  match Miou.care orphans with
+  | None | Some None -> ()
+  | Some (Some prm) ->
+      match Miou.await prm with
+      | Ok () -> clean orphans
+      | Error exn ->
+          Logs.err (fun m -> m "Unexpected exception from an ICMPv4 task: %s"
+            (Printexc.to_string exn));
+          clean orphans
+
+let rec handler t =
+  clean t.orphans;
+  let todo = Miou.Mutex.protect t.mutex @@ fun () ->
+    while Queue.is_empty t.queue
+    do Miou.Condition.wait t.condition t.mutex done;
+    let todo = Queue.create () in
+    Queue.transfer t.queue todo; todo in
+  let fn (pkt, payload) =
+    ignore (Miou.async ~orphans:t.orphans @@ fun () -> input t.ipv4 pkt payload) in
+  Queue.iter fn todo;
+  handler t
+
+type daemon = unit Miou.t * t
+
+let handler ipv4 : daemon =
+  let mutex = Miou.Mutex.create () in
+  let condition = Miou.Condition.create () in
+  let queue = Queue.create () in
+  let orphans = Miou.orphans () in
+  let t = { mutex; condition; queue; ipv4; orphans } in
+  Miou.async (fun () -> handler t), t
+
+let kill (prm, _) = Miou.cancel prm
+
+let transfer (_, t) (pkt, payload) =
+  let payload = match payload with
+    | IPv4.Slice bstr -> Slice_bstr.to_string bstr
+    | IPv4.String str -> str in
+  Miou.Mutex.protect t.mutex @@ fun () ->
+  Queue.push (pkt, payload) t.queue;
+  Miou.Condition.signal t.condition

--- a/miou-solo5/ipv4_miou_solo5.ml
+++ b/miou-solo5/ipv4_miou_solo5.ml
@@ -1,0 +1,472 @@
+let src = Logs.Src.create "ipv4-miou-solo5"
+
+module Log = (val Logs.src_log src : Logs.LOG)
+module SBstr = Slice_bstr
+
+module Flag = struct
+  type t = DF | MF
+
+  let _dfmf = [ DF; MF ]
+  let _df = [ DF ]
+  let _mf = [ MF ]
+  let _none = []
+
+  let of_int cmd =  match cmd land 0b11 with
+    | 0b11 -> _dfmf
+    | 0b10 -> _df
+    | 0b01 -> _mf
+    | _ -> _none
+
+  let to_int flags =
+    let cmd = ref 0 in
+    let fn = function
+      | DF -> cmd := !cmd lor 0b10
+      | MF -> cmd := !cmd lor 0b01 in
+    List.iter fn flags; !cmd
+end
+
+module Packet = struct
+  type partial = Partial
+  type complete = { checksum : int; length : int }
+
+  type 'a packet =
+    { src : Ipaddr.V4.t
+    ; dst : Ipaddr.V4.t
+    ; uid : int
+    ; flags : Flag.t list
+    ; off : int
+    ; ttl : int
+    ; protocol : int
+    ; checksum_and_length : 'a
+    ; opt : Slice_bstr.t }
+
+  let pp_error ppf = function
+    | `Invalid_IPv4_packet -> Fmt.string ppf "bad packet"
+    | `Invalid_checksum -> Fmt.string ppf "bad checksum"
+    | `Msg msg -> Fmt.string ppf msg
+
+  let guard err fn = if fn () then Ok () else Error err
+
+  let decode slice =
+    let ( let* ) = Result.bind in
+    let version_and_ihl = SBstr.get_uint8 slice 0 in
+    let ihl = version_and_ihl land 0b1111 in
+    let* () = guard `Invalid_IPv4_packet @@ fun () ->
+      SBstr.length slice >= 20 in
+    let length = SBstr.get_uint16_be slice 2 in
+    let uid = SBstr.get_uint16_be slice 4 in
+    let flags_and_off = SBstr.get_uint16_be slice 6 in
+    let flags = Flag.of_int (flags_and_off lsr 13) in
+    let off = flags_and_off land 0x1fff in
+    let ttl = SBstr.get_uint8 slice 8 in
+    let protocol = SBstr.get_uint8 slice 9 in
+    let checksum = SBstr.get_uint16_be slice 10 in
+    let chk =
+      let { Slice.buf; off; _ } = slice in
+      Bstr.set_uint16_be buf (off + 10) 0;
+      Utcp.Checksum.digest ~off ~len:(ihl * 4) buf in
+    let* () = guard `Invalid_checksum @@ fun () -> checksum == chk in
+    let src = Ipaddr.V4.of_int32 (SBstr.get_int32_be slice 12) in
+    let dst = Ipaddr.V4.of_int32 (SBstr.get_int32_be slice 16) in
+    let opt =
+      if ihl == 5
+      then SBstr.empty
+      else SBstr.sub slice ~off:20 ~len:((ihl * 4) - 20) in
+    let checksum_and_length = { checksum; length } in
+    let pkt = { src; dst; uid; flags; off; ttl; protocol; checksum_and_length; opt } in
+    let payload = SBstr.shift slice (20 + SBstr.length opt) in
+    Ok (pkt, payload)
+
+  let flags_and_off_to_int t =
+    let flags = Flag.to_int t.flags in
+    (flags lsl 13) lor t.off
+
+  let unsafe_encode_into t ?(off= 0) bstr =
+    let version_and_ihl = (4 lsl 4) lor 5 in
+    Bstr.set_uint8 bstr (off + 0) version_and_ihl;
+    Bstr.set_uint8 bstr (off + 1) 0;
+    Bstr.set_uint16_be bstr (off + 2) 0;
+    Bstr.set_uint16_be bstr (off + 4) t.uid;
+    Bstr.set_uint16_be bstr (off + 6) (flags_and_off_to_int t);
+    Bstr.set_uint8 bstr (off + 8) t.ttl;
+    Bstr.set_uint8 bstr (off + 9) t.protocol;
+    Bstr.set_uint16_be bstr (off + 10) 0;
+    Bstr.set_int32_be bstr (off + 12) (Ipaddr.V4.to_int32 t.src);
+    Bstr.set_int32_be bstr (off + 16) (Ipaddr.V4.to_int32 t.dst)
+end
+
+module Key = struct
+  type t =
+    { src : Ipaddr.V4.t
+    ; dst : Ipaddr.V4.t
+    ; protocol : int
+    ; uid : int }
+
+  let equal a b =
+    Ipaddr.V4.compare a.src b.src == 0
+    && Ipaddr.V4.compare a.dst b.dst == 0
+    && a.protocol == b.protocol
+    && a.uid == b.uid
+
+  let hash = Hashtbl.hash
+end
+
+module Value = struct
+  type t =
+    { to_expire : int
+    ; fragment : Fragment.t
+    ; count : int }
+
+  let weight { fragment; _ } = Fragment.weight fragment
+end
+
+module Cache = Lru.M.Make (Key) (Value)
+
+module Fragments = struct
+  let src = Logs.Src.create "fragments"
+
+  module Log = (val Logs.src_log src : Logs.LOG)
+
+  type t =
+    { cache : Cache.t
+    ; to_expire : int }
+
+  let max_expiration = Int64.to_int (Duration.of_sec 10)
+
+  let create ?(to_expire= max_expiration) () =
+    { cache= Cache.create (1024*256)
+    ; to_expire }
+
+  let catch ~on_exn fn =
+    try fn () with exn -> on_exn exn
+
+  type payload =
+    | Slice of SBstr.t
+    | String of string
+
+  let insert t pkt slice =
+    let src = pkt.Packet.src
+    and dst = pkt.Packet.dst
+    and protocol = pkt.Packet.protocol
+    and uid = pkt.Packet.uid
+    and off = pkt.Packet.off * 8
+    and limit = not (List.exists ((==) Flag.MF) pkt.Packet.flags) in
+    let key = { Key.src; dst; protocol; uid } in
+    let now = Miou_solo5.clock_monotonic () in
+    match off, limit, Cache.find key t.cache with
+    | 0, true, None -> Some (key, Slice slice) (* unfragmented packed *)
+    | _, _, None ->
+        (* NOTE(dinosaure): we have an new fragment which is not recorded
+           into our cache. We [add] this new fragment and [trim] our
+           cache to avoid an OOM. *)
+        let fragment = Fragment.singleton ~off ~limit slice in
+        let value = { Value.to_expire= now + t.to_expire; count= 1; fragment } in
+        Cache.add key value t.cache;
+        Cache.trim t.cache;
+        None
+    | _, _, Some { count; _ } when count > 16 ->
+        (* NOTE(dinosaure): from @hannesm, if we have more than 16
+           fragments, we just delete our entry from our cache. *)
+        Cache.remove key t.cache;
+        None
+    | _, _, Some { to_expire; _ } when to_expire < now ->
+        (* NOTE(dinosaure): from @hannesm, if we found an entry and get a new
+           fragment [max_expiration]ns (10secs), we delete the old entry
+           and create a new one. *)
+        let fragment = Fragment.singleton ~off ~limit slice in
+        let value = { Value.to_expire= now + t.to_expire; count= 1; fragment } in
+        Cache.add key value t.cache;
+        None
+    | _, _, Some { fragment; count; to_expire } ->
+        (* NOTE(dinosaure): the basic execution path. If the fragment does not
+           fit into our entry, we remove it. Otherwise, we insert the new
+           incoming fragment. If the resulted entry is fullfilled, we returns
+           the result. Otherwise, we update our cache with our new entry and
+           [trim] our cache to avoid an OOM.
+
+           NOTE(dinosaure): [Cache.add] does a promotion of our entry into our
+           cache also. *)
+        let on_exn _exn = Cache.remove key t.cache; None in
+        catch ~on_exn @@ fun () ->
+        let str = SBstr.to_string slice in
+        let fragment = Fragment.insert fragment ~off ~limit str in
+        if Fragment.is_complete fragment
+        then begin
+          Log.debug (fun m -> m "fragment is complete");
+          let str = Fragment.reassemble_exn fragment in
+          Cache.remove key t.cache;
+          Some (key, String str)
+        end else begin
+          let value = { Value.fragment; count= count + 1; to_expire } in
+          Cache.add key value t.cache;
+          Cache.trim t.cache;
+          None
+        end
+end
+
+module Ethernet = Ethernet_miou_solo5
+module ARPv4 = Arp_miou_solo5
+
+type packet = Key.t =
+  { src : Ipaddr.V4.t
+  ; dst : Ipaddr.V4.t
+  ; protocol : int
+  ; uid : int }
+
+and payload = Fragments.payload =
+  | Slice of SBstr.t
+  | String of string
+
+type t =
+  { eth : Ethernet.t
+  ; arp : ARPv4.t
+  ; cidr : Ipaddr.V4.Prefix.t
+  ; gateway : Ipaddr.V4.t option
+  ; cache : Fragments.t
+  ; mutable handler : (packet * payload) -> unit
+  ; src : Logs.src }
+
+module Writer = struct
+  type z = |
+  type 'a s = |
+
+  type 'a peano =
+    | Zero : z peano
+    | Succ : 'a peano -> 'a s peano
+
+  [@@@warning "-27"]
+  [@@@warning "-37"]
+
+  type ('p, 'q, 'a) m =
+    | Bind : ('p, 'q, 'a) m * ('a -> ('q, 'r, 'b) m) -> ('p, 'r, 'b) m
+    | Return : 'a -> ('p, 'p, 'a) m
+    | Write : ('n s, 'm s, 'a) m * (Bstr.t -> int) -> ('n, 'm s, 'a) m
+
+  type ipv4 = t
+
+  type t =
+    | Fixed of { total_length : int; fn : (Bstr.t -> unit) }
+      (* invariant: [total_length <= mtu - 20] *)
+    | Fragmented of { total_length : int; fn : (Bstr.t -> unit) Seq.t }
+      (* invariant: [bstr] is filled to [(mtu - 20) land (lnot 0b111)]
+         until the last element (which contains remaining unaligned bytes. *)
+    | Unknown : (z, 'n s, unit) m -> t
+
+  let of_string t str =
+    let mtu = Ethernet.mtu t.eth in
+    let total_length = String.length str in
+    if 20 + total_length <= mtu
+    then
+      let len = total_length in
+      let fn = Bstr.blit_from_string str ~src_off:0 ~dst_off:0 ~len in
+      Fixed { total_length; fn }
+    else
+      let fragment = (mtu - 20) land (lnot 0b111) in
+      let rec go src_off () =
+        if src_off == total_length then Seq.Nil
+        else
+          let len = Int.min (total_length - src_off) fragment in
+          let fn = Bstr.blit_from_string str ~src_off ~dst_off:0 ~len in
+          Seq.Cons (fn, go (src_off + len)) in
+      Fragmented { total_length; fn= go 0 }
+
+  let chunk chunk_size ?(str_off= 0) sstr =
+    let rec go acc str_off chunk_size sstr =
+      if chunk_size == 0
+      then (List.rev acc, str_off, sstr)
+      else match sstr with
+        | [] -> (List.rev acc, str_off, sstr)
+        | str :: sstr as lst ->
+          let len = Int.min chunk_size (String.length str - str_off) in
+          let acc = (str, str_off, len) :: acc in
+          if str_off + len == String.length str
+          then go acc 0 (chunk_size - len) sstr
+          else go acc (str_off + len) (chunk_size - len) lst in
+    go [] str_off chunk_size sstr
+
+  let of_strings t sstr =
+    let mtu = Ethernet.mtu t.eth in
+    let total_length =
+      let fn acc str = acc + String.length str in
+      List.fold_left fn 0 sstr in
+    if 20 + total_length <= mtu
+    then
+      let bufs = Array.of_list sstr in
+      let fn bstr =
+        let dst_off = ref 0 in
+        for i = 0 to Array.length bufs - 1 do
+          let str = Array.unsafe_get bufs i in
+          let len = String.length str in
+          Bstr.blit_from_string str ~src_off:0 bstr ~dst_off:!dst_off ~len;
+          dst_off := !dst_off + len
+        done in
+      Fixed { total_length; fn }
+    else
+      let fragment = (mtu - 20) land (lnot 0b111) in
+      let rec go (str_off, sstr) () = match sstr with
+        | [] -> Seq.Nil
+        | sstr ->
+            let chunk, str_off, sstr = chunk fragment ~str_off sstr in
+            let chunk = Array.of_list chunk in
+            let fn bstr =
+              let dst_off = ref 0 in
+              for i = 0 to Array.length chunk - 1 do
+                let str, src_off, len = Array.unsafe_get chunk i in
+                Bstr.blit_from_string str ~src_off bstr ~dst_off:!dst_off ~len;
+                dst_off := !dst_off + len
+              done in
+            Seq.Cons (fn, go (str_off, sstr)) in
+      let fn = go (0, sstr) in
+      Fragmented { total_length; fn }
+
+  let into t ~len:total_length fn =
+    if 20 + total_length > Ethernet.mtu t.eth
+    then invalid_arg "IPv4.Writer.into: too huge IPv4 packet";
+    Fixed { total_length; fn }
+
+  let unknown : type n. (z, n s, unit) m -> t = fun m -> Unknown m
+
+  let ( let* ) x fn = Bind (x, fn)
+  let ( let+ ) x fn = Write (x, fn)
+  let return x = Return x
+
+  type 'a user's_fn =
+    | Some : (Bstr.t -> int) -> 'a s user's_fn
+    | None : z user's_fn
+
+  type out = (Bstr.t -> int) -> unit
+
+  let rec go : type a p q. out:out -> p peano -> p user's_fn -> (p, q, a) m -> (q peano * q user's_fn * a)
+    = fun ~out s user's_fn0 m -> match m, s with
+    | Return x, _ -> (s, user's_fn0, x)
+    | Bind (m, fn), s ->
+        let s, user's_fn1, x = go ~out s user's_fn0 m in
+        go ~out s user's_fn1 (fn x)
+    | Write (m, user's_fn1), s ->
+        let () = match user's_fn0 with None -> ()
+          | Some user's_fn0 -> out user's_fn0 in
+        go ~out (Succ s) (Some user's_fn1) m
+end
+
+let guard err fn = if fn () then Ok () else Error err
+
+let create ?to_expire eth arp ?gateway ?(handler= ignore) cidr =
+  let src = Logs.Src.create (Ipaddr.V4.Prefix.to_string cidr) in
+  let t = { eth; arp; cidr; gateway
+          ; cache= Fragments.create ?to_expire ()
+          ; handler
+          ; src } in
+  let ( let* ) = Result.bind in
+  let* () = guard `MTU_too_small @@ fun () -> Ethernet.mtu eth >= 20 + 1 in
+  Ok t
+
+let max t =
+  let mtu = Ethernet.mtu t.eth in
+  mtu - 20
+
+let src t = Ipaddr.V4.Prefix.address t.cidr
+
+let fixed pkt user's_fn len bstr =
+  Packet.unsafe_encode_into pkt bstr;
+  Bstr.set_uint16_be bstr 2 (20 + len);
+  let rest = Bstr.sub bstr ~off:20 ~len in
+  user's_fn rest;
+  let chk = Utcp.Checksum.digest ~off:0 ~len:20 bstr in
+  Bstr.set_uint16_be bstr 10 chk;
+  20 + len
+
+let write t ?(ttl= 38) ?src dst ~protocol p =
+  Logs.debug ~src:t.src (fun m -> m "Asking where is %a" Ipaddr.V4.pp dst);
+  match Routing.destination_macaddr t.cidr t.gateway t.arp dst with
+  | Error (`Exn _ | `Timeout | `Clear) ->
+      Logs.err ~src:t.src (fun m -> m "no route found for %a" Ipaddr.V4.pp dst);
+      Error `Route_not_found
+  | Error `Gateway ->
+      Logs.debug ~src:t.src (fun m -> m "no gateway specified for writing IPv4 packets");
+      Ok ()
+  | Ok macaddr ->
+      Logs.debug ~src:t.src (fun m -> m "%a is-at %a" Ipaddr.V4.pp dst Macaddr.pp macaddr);
+      let src = Option.value ~default:(Ipaddr.V4.Prefix.address t.cidr) src in
+      let mtu = Ethernet.mtu t.eth in
+      match p with
+      | Writer.Fixed { total_length; fn= user's_fn; } ->
+          let pkt =
+            { Packet.src; dst; uid= 0; flags= Flag._none; off= 0; ttl
+            ; protocol; checksum_and_length= Packet.Partial
+            ; opt= SBstr.empty } in
+          let protocol = Ethernet.IPv4 in
+          let fn = fixed pkt user's_fn total_length in
+          Ethernet.write_directly_into t.eth ~dst:macaddr ~protocol fn;
+          Ok ()
+      | Writer.Fragmented { total_length; fn; } ->
+          let uid = Mirage_crypto_rng.generate 2 in
+          let uid = String.get_uint16_be uid 0 in
+          let rec go off total_length = function
+            | Seq.Nil -> ()
+            | Seq.Cons (user's_fn, next) ->
+                let next = next () in
+                let size = Int.min total_length (mtu - 20) in
+                let flags =
+                  if next != Seq.Nil then Flag._mf else Flag._none in
+                let pkt =
+                  { Packet.src; dst; uid; flags; off= off lsr 3; ttl; protocol
+                  ; checksum_and_length= Packet.Partial; opt= SBstr.empty } in
+                let protocol = Ethernet.IPv4 in
+                let fn = fixed pkt user's_fn size in
+                Ethernet.write_directly_into t.eth ~dst:macaddr ~protocol fn;
+                if next != Seq.Nil && total_length - size > 0
+                then go (off + size) (total_length - size) next in
+          go 0 total_length (fn ());
+          Ok ()
+      | Writer.Unknown m ->
+          let uid = Mirage_crypto_rng.generate 2 in
+          let uid = String.get_uint16_be uid 0 in
+          let off = ref 0 in
+          let out ~last user's_fn =
+            let fn bstr =
+              let flags = if last then Flag._none else Flag._mf in
+              let pkt =
+                { Packet.src; dst; uid; flags; off= !off lsr 3; ttl
+                ; protocol ; checksum_and_length= Packet.Partial
+                ; opt= SBstr.empty } in
+              Packet.unsafe_encode_into pkt bstr;
+              let len = user's_fn (Bstr.sub bstr ~off:20 ~len:(Bstr.length bstr - 20)) in
+              Bstr.set_uint16_be bstr 2 (20 + len);
+              let len = (len + 0b111) / 8 * 8 in
+              off := !off + len;
+              let chk = Utcp.Checksum.digest ~off:0 ~len:20 bstr in
+              Bstr.set_uint16_be bstr 10 chk;
+              20 + len in
+            let protocol = Ethernet.IPv4 in
+            Ethernet.write_directly_into t.eth ~dst:macaddr ~protocol fn in
+          let _, Writer.Some user's_fn, () =
+            Writer.go ~out:(out ~last:false) Writer.Zero Writer.None m in
+          out ~last:true user's_fn;
+          Ok ()
+
+let input t pkt =
+  match Packet.decode pkt.Ethernet.payload with
+  | Error err ->
+      let str = SBstr.to_string pkt.payload in
+      Logs.err ~src:t.src (fun m -> m "Invalid IPv4 packet: %a" Packet.pp_error err);
+      Logs.err ~src:t.src (fun m -> m "@[<hov>%a@]" (Hxd_string.pp Hxd.default) str)
+  | Ok (ipv4, payload) ->
+      let dst = ipv4.Packet.dst in
+      if SBstr.length payload > 0
+      && (Ipaddr.V4.(compare dst (Prefix.address t.cidr)) == 0
+          || Ipaddr.V4.(compare dst Ipaddr.V4.broadcast) == 0
+          || Ipaddr.V4.(compare dst (Prefix.broadcast t.cidr)) == 0)
+      then begin
+        Logs.debug ~src:t.src (fun m -> m "Incoming IPv4 packet from %a"
+          Ipaddr.V4.pp ipv4.Packet.src);
+        let pkt = Fragments.insert t.cache ipv4 payload in
+        Option.iter t.handler pkt
+      end
+
+let _cnt = Atomic.make 0
+
+let set_handler t handler =
+  Atomic.incr _cnt;
+  t.handler <- handler;
+  if Atomic.get _cnt > 1
+  then Logs.warn ~src:t.src (fun m -> m "IPv4 handler modified more than once")

--- a/miou-solo5/ipv4_miou_solo5.mli
+++ b/miou-solo5/ipv4_miou_solo5.mli
@@ -1,0 +1,64 @@
+module Ethernet = Ethernet_miou_solo5
+module ARPv4 = Arp_miou_solo5
+
+type t
+
+type packet =
+  { src : Ipaddr.V4.t
+  ; dst : Ipaddr.V4.t
+  ; protocol : int
+  ; uid : int }
+
+and payload =
+  | Slice of Slice_bstr.t
+  | String of string
+
+val create :
+     ?to_expire:int
+  -> Ethernet.t
+  -> ARPv4.t
+  -> ?gateway:Ipaddr.V4.t
+  -> ?handler:((packet * payload) -> unit)
+  -> Ipaddr.V4.Prefix.t
+  -> (t, [> `MTU_too_small ]) result
+
+val max : t -> int
+val src : t -> Ipaddr.V4.t
+
+module Writer : sig
+  type ipv4 = t
+  type t
+
+  val of_string : ipv4 -> string -> t
+  val of_strings : ipv4 -> string list -> t
+  val into : ipv4 -> len:int -> (Bstr.t -> unit) -> t
+
+  type ('p, 'q, 'a) m
+  type z
+  type 'a s
+
+  val ( let* ) : ('p, 'q, 'a) m -> ('a -> ('q, 'r, 'b) m) -> ('p, 'r, 'b) m
+  val ( let+ ) : ('p s, 'q s, 'a) m -> (Bstr.t -> int) -> ('p, 'q s, 'a) m
+  val return : 'a -> ('p, 'p, 'a) m
+  val unknown : (z, 'n s, unit) m -> t
+end
+
+val write :
+     t
+  -> ?ttl:int
+  -> ?src:Ipaddr.V4.t
+  -> Ipaddr.V4.t
+  -> protocol:int
+  -> Writer.t
+  -> (unit, [> `Route_not_found ]) result
+(** [write ?ttl ?src dst protocol ?finally ?size sstr] writes a new IPv4
+    packet (fragmented or not) to the specified destination [dst].
+
+    The layer above IPv4 (notably TCP) may require the IPv4 "pseudo-header"
+    before generating its own header (notably to calculate a checksum). The
+    [finally] function is called with this pseudo-header and must return the
+    header of the layer above IPv4. The size of this header must be known in
+    advance via the [size] argument. *)
+
+val input : t -> Slice_bstr.t Ethernet.packet -> unit
+val set_handler : t -> ((packet * payload) -> unit) -> unit

--- a/miou-solo5/ropes.ml
+++ b/miou-solo5/ropes.ml
@@ -1,0 +1,112 @@
+let src = Logs.Src.create "ropes"
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+type fixed = |
+type unknown = |
+
+type 'a t =
+  | Str : string -> fixed t
+  | Unknown : 'a size -> 'a t
+  | App : { l : fixed t; r : 'a t
+          ; weight : int
+          ; l_len : int
+          ; r_len : 'a size } -> 'a t
+and 'a size =
+  | Length : int -> fixed size
+  | Limitless : unknown size
+
+let weight : type a. a t -> int = function
+  | Str str -> String.length str
+  | Unknown _ -> 0
+  | App { weight; _ } -> weight
+
+let ( <+> ) : type a. a size -> int -> a size = function
+  | Length a -> fun b -> Length (a + b)
+  | Limitless -> fun _ -> Limitless
+
+let length : type a. a t -> a size = function
+  | Unknown v ->  v
+  | Str str -> Length (String.length str)
+  | App { r_len= Limitless; _ } -> Limitless
+  | App { l_len; r_len; _ } -> r_len <+> l_len
+
+exception Out_of_bounds
+exception Overlap
+
+let () = Printexc.register_printer @@ function
+  | Out_of_bounds -> Some "Fragment out of bounds"
+  | Overlap -> Some "Fragment overlap"
+  | _ -> None
+
+let rec insert
+  : type a. off:int -> string -> a t -> a t
+  = fun ~off str -> function
+  | Unknown Limitless ->
+      let l = Unknown (Length off) in
+      let rl = Str str in
+      let rr = Unknown Limitless in
+      let l_len = String.length str in
+      let weight = String.length str in
+      let r = App { l= rl; r= rr; weight; l_len; r_len= Limitless } in
+      App { l; r; weight; l_len= off; r_len= Limitless }
+  | Unknown (Length top) ->
+      if off < 0
+      || off > top - String.length str
+      then raise_notrace Out_of_bounds;
+      if off + String.length str == top
+      then
+        let l = Unknown (Length off) in
+        let r = Str str in
+        let len = String.length str in
+        let weight = String.length str in
+        App { l; r; weight; l_len= off; r_len= Length len }
+      else
+        let l = Unknown (Length off) in
+        let rl = Str str in
+        let r_len = Length (top - off - String.length str) in
+        let rr = Unknown r_len in
+        let len = String.length str in
+        let weight = String.length str in
+        let r = App { l= rl; r= rr; weight; l_len= len; r_len } in
+        let r_len = r_len <+> String.length str in
+        App { l; r; weight; l_len= off; r_len }
+  | App { l; r; weight; l_len; r_len } ->
+      if off < l_len
+      then
+        let l = insert ~off str l in
+        let weight = weight + String.length str in
+        App { l; r; weight; l_len; r_len }
+      else
+        let r = insert ~off:(off - l_len) str r in
+        let weight = weight + String.length str in
+        let r_len = length r in
+        App { l; r; weight; l_len; r_len }
+  | Str _ -> raise_notrace Overlap
+
+let rec fixed : max:int -> unknown t -> fixed t
+  = fun ~max -> function
+  | Unknown Limitless -> Unknown (Length max)
+  | App { l; r; weight; l_len; r_len= Limitless } ->
+      let r = fixed ~max:(max - l_len) r in
+      let r_len = length r in
+      App { l; r; weight; l_len; r_len }
+
+let to_bytes : fixed t -> Diet.t * bytes = fun t ->
+  let Length len = length t in
+  let buf = Bytes.create len in
+  let rec go diet off = function
+    | Str str ->
+      let len = String.length str in
+      Bytes.blit_string str 0 buf off len;
+      Log.debug (fun m -> m "+[%d, %d]" off (off + len));
+      Diet.add ~off ~len diet
+    | Unknown (Length 0) -> diet
+    | Unknown (Length len) ->
+      Bytes.fill buf off len '\000';
+      Log.debug (fun m -> m "+[%d, %d] (unknown)" off (off + len));
+      Diet.add ~off ~len diet
+    | App { l; r; l_len; _ } ->
+      let diet = go diet off l in
+      go diet (off + l_len) r in
+  let diet = go Diet.empty 0 t in diet, buf

--- a/miou-solo5/ropes.mli
+++ b/miou-solo5/ropes.mli
@@ -1,0 +1,22 @@
+type fixed = |
+type unknown = |
+
+type 'a t =
+  | Str : string -> fixed t
+  | Unknown : 'a size -> 'a t
+  | App : { l : fixed t; r : 'a t
+          ; weight : int
+          ; l_len : int
+          ; r_len : 'a size } -> 'a t
+and 'a size =
+  | Length : int -> fixed size
+  | Limitless : unknown size
+
+exception Out_of_bounds
+exception Overlap
+
+val length : 'a t -> 'a size
+val weight : 'a t -> int
+val insert : off:int -> string -> 'a t -> 'a t
+val fixed : max:int -> unknown t -> fixed t
+val to_bytes : fixed t -> Diet.t * bytes

--- a/miou-solo5/routing.ml
+++ b/miou-solo5/routing.ml
@@ -1,0 +1,29 @@
+module ARPv4 = Arp_miou_solo5
+
+let broadcast = Ok Macaddr.broadcast
+
+let macaddr_of_multicast ipaddr =
+  let buf = Ipaddr.V4.to_octets ipaddr in
+  let mac = Bytes.create 6 in
+  Bytes.set_uint8 mac 0 0x01;
+  Bytes.set_uint8 mac 1 0x00;
+  Bytes.set_uint8 mac 2 0x5e;
+  Bytes.set_uint8 mac 3 (String.get_uint8 buf 1 land 0x7f);
+  Bytes.set_uint8 mac 4 (String.get_uint8 buf 2);
+  Bytes.set_uint8 mac 5 (String.get_uint8 buf 3);
+  Macaddr.of_octets_exn (Bytes.unsafe_to_string mac)
+
+let destination_macaddr network gateway arp ipaddr =
+  if Ipaddr.V4.(compare broadcast) ipaddr == 0
+  || Ipaddr.V4.(compare any) ipaddr == 0
+  || Ipaddr.V4.(compare (Prefix.broadcast network)) ipaddr == 0
+  then broadcast
+  else if Ipaddr.V4.is_multicast ipaddr
+  then Ok (macaddr_of_multicast ipaddr)
+  else if Ipaddr.V4.Prefix.mem ipaddr network
+  then ARPv4.query arp ipaddr
+  else
+    match gateway with
+    | None -> Error `Gateway
+    | Some gateway ->
+        ARPv4.query arp gateway

--- a/miou-solo5/udpv4_miou_solo5.ml
+++ b/miou-solo5/udpv4_miou_solo5.ml
@@ -1,0 +1,129 @@
+let src = Logs.Src.create "udpv4-miou-solo5"
+
+module Log = (val Logs.src_log src : Logs.LOG)
+module SBstr = Slice_bstr
+module IPv4 = Ipv4_miou_solo5
+
+module Packet = struct
+  type t =
+    { src_port : int
+    ; dst_port : int
+    ; length : int }
+
+  let guard err fn = if fn () then Ok () else Error err
+
+  let decode slice =
+    let ( let* ) = Result.bind in
+    let* () = guard `Invalid_UDPv4_packet @@ fun () ->
+      SBstr.length slice >= 8 in
+    let len0 = SBstr.get_uint16_be slice 4 in
+    let len1 = len0 - 8 in
+    let* () = guard `Invalid_UDPv4_packet @@ fun () ->
+      len0 >= 8 && len1 <= SBstr.length slice - 8 in
+    let src_port = SBstr.get_uint16_be slice 0 in
+    let dst_port = SBstr.get_uint16_be slice 2 in
+    let payload = SBstr.sub slice ~off:8 ~len:len1 in
+    Ok ({ src_port; dst_port; length= len1 }, payload)
+
+  let encode ~src ~dst { src_port; dst_port; length } ~off ~len payload =
+    let buf = Bytes.make 8 '\000' in
+    Bytes.set_uint16_be buf 0 src_port;
+    Bytes.set_uint16_be buf 2 dst_port;
+    Bytes.set_uint16_be buf 4 (length + 8);
+    Bytes.set_uint16_be buf 6 0;
+    let pseudo_header = Bytes.make 12 '\000' in
+    Bytes.set_int32_be pseudo_header 0 (Ipaddr.V4.to_int32 src);
+    Bytes.set_int32_be pseudo_header 4 (Ipaddr.V4.to_int32 dst);
+    Bytes.set_uint8 pseudo_header 9 17;
+    Bytes.set_uint16_be pseudo_header 10 (length + 8);
+    let sum = 0 in
+    let sum = Utcp.Checksum.feed_string sum ~off:0 ~len:12 (Bytes.unsafe_to_string pseudo_header) in
+    let sum = Utcp.Checksum.feed_string sum ~off:0 ~len:8 (Bytes.unsafe_to_string buf) in
+    let sum = Utcp.Checksum.feed_string sum ~off ~len payload in
+    let chk = Utcp.Checksum.finally sum in
+    Bytes.set_uint16_be buf 6 chk;
+    Bytes.unsafe_to_string buf
+end
+
+type out =
+  { length : int
+  ; peer : Ipaddr.V4.t
+  ; port : int }
+
+type waiter =
+  { buf : bytes
+  ; dst_off: int
+  ; len : int
+  ; waiter : out Miou.Computation.t }
+
+type state =
+  { readers : (int, waiter list) Hashtbl.t
+  ; ipv4 : IPv4.t }
+
+let create ipv4 =
+  { readers= Hashtbl.create 0x7ff
+  ; ipv4 }
+
+let pp_reader ppf _ = Fmt.pf ppf "#reader"
+
+let fill state ~peer ~pkt payload =
+  Log.debug (fun m -> m "@[<hov>%a@]" Fmt.(Dump.hashtbl int pp_reader) state.readers);
+  match Hashtbl.find state.readers pkt.Packet.dst_port with
+  | exception Not_found -> ()
+  | waiters ->
+      let fn { buf; dst_off; len; waiter } =
+        let length = Int.min len (SBstr.length payload) in
+        let out = { length; peer; port= pkt.Packet.src_port } in
+        SBstr.blit_to_bytes payload ~src_off:0 buf ~dst_off ~len:length;
+        assert (Miou.Computation.try_return waiter out) in
+      List.iter fn waiters;
+      Hashtbl.remove state.readers pkt.Packet.dst_port
+      (* TODO(dinosaure): we need to check that [Miou.Computation.try_return] does not
+         re-schedule. If it's the case, it's safe to [Hashtbl.remove]. Otherwise, we must
+         aggregate everything into a list, remove and apply our [fn] to the list. *)
+
+let handler state (pkt, payload) =
+  let peer = pkt.IPv4.src in
+  match payload with
+  | IPv4.String _str -> assert false
+  | IPv4.Slice slice ->
+      match Packet.decode slice with
+      | Ok (pkt, payload) ->
+          Log.debug (fun m -> m "New incoming UDPv4 packet");
+          fill state ~peer ~pkt payload
+      | Error _ -> Log.err (fun m -> m "Invalid UDPv4 packet, ignore it")
+
+let recvfrom state ?src:_ ~port ?(off= 0) ?len buf =
+  let len = match len with
+    | Some len -> len
+    | None -> Bytes.length buf - off in
+  if off < 0 || len < 0 || off > Bytes.length buf - len
+  then invalid_arg "UDPv4.recvfrom: out of bounds";
+  let waiter = { buf; dst_off= off; len; waiter= Miou.Computation.create () } in
+  match Hashtbl.find state.readers port with
+  | exception Not_found ->
+      Hashtbl.add state.readers port [ waiter ];
+      Log.debug (fun m -> m "Add a new reader on *:%d" port);
+      Log.debug (fun m -> m "@[<hov>%a@]" Fmt.(Dump.hashtbl int pp_reader) state.readers);
+      let { length; peer; port; } = Miou.Computation.await_exn waiter.waiter in
+      length, (peer, port)
+  | waiters ->
+      Hashtbl.replace state.readers port (waiter :: waiters);
+      let { length; peer; port; } = Miou.Computation.await_exn waiter.waiter in
+      length, (peer, port)
+
+let sendto state ~dst ?src_port ~port:dst_port ?(off= 0) ?len payload =
+  let len =  match len with
+    | Some len -> len
+    | None -> String.length payload - off in
+  if off < 0 || len < 0
+  || off > String.length payload - len
+  then invalid_arg "UDPv4.sendto: out of bounds";
+  let src_port : int = match src_port with
+    | Some src_port -> src_port
+    | None -> String.get_uint16_ne (Mirage_crypto_rng.generate 2) 0 in
+  let src = IPv4.src state.ipv4 in
+  let pkt = { Packet.src_port; dst_port; length= len } in
+  let str = Packet.encode ~src ~dst pkt ~off ~len payload in
+  let writer = IPv4.Writer.of_strings state.ipv4 [ str; payload ] in
+  IPv4.write state.ipv4 dst ~protocol:17 writer

--- a/miou-solo5/udpv4_miou_solo5.mli
+++ b/miou-solo5/udpv4_miou_solo5.mli
@@ -1,0 +1,19 @@
+module IPv4 = Ipv4_miou_solo5
+
+type state
+
+val create : IPv4.t -> state
+
+val recvfrom : state ->
+  ?src:Ipaddr.V4.t ->
+  port:int ->
+  ?off:int -> ?len:int -> bytes -> int * (Ipaddr.V4.t * int)
+
+val sendto: state ->
+  dst:Ipaddr.V4.t ->
+  ?src_port:int ->
+  port:int ->
+  ?off:int ->
+  ?len:int -> string -> (unit, [> `Route_not_found ]) result
+
+val handler : state -> IPv4.packet * IPv4.payload -> unit

--- a/miou-solo5/utcp_miou_solo5.ml
+++ b/miou-solo5/utcp_miou_solo5.ml
@@ -1,0 +1,507 @@
+module Ethernet = Ethernet_miou_solo5
+module ARPv4 = Arp_miou_solo5
+module IPv4 = Ipv4_miou_solo5
+module ICMPv4 = Icmpv4_miou_solo5
+module UDPv4 = Udpv4_miou_solo5
+
+exception Net_unreach
+exception Closed_by_peer
+exception Connection_refused
+
+module Buffer = struct
+  type t =
+    { mutable bstr : Bstr.t
+    ; mutable off : int
+    ; mutable len : int }
+
+  let create size =
+    let bstr = Bstr.create size in
+    { bstr; off= 0; len= 0 }
+
+  let available { bstr; off; len; } =
+    Bstr.length bstr - off - len
+
+  let length { len; _ } = len
+
+  let compress t =
+    if t.len == 0 then begin
+      t.off <- 0;
+      t.len <- 0
+    end else if t.off > 0 then begin
+      Bstr.blit t.bstr ~src_off:t.off t.bstr ~dst_off:0 ~len:t.len;
+      t.off <- 0;
+    end
+
+  let get t ~fn =
+    let n = fn t.bstr ~off:t.off ~len:t.len in
+    t.off <- t.off + n;
+    t.len <- t.len - n;
+    if t.len == 0 then t.off <- 0;
+    n
+
+  let put t ~fn =
+    compress t;
+    let off = t.off + t.len in
+    let bstr = t.bstr in
+    if Bstr.length bstr == t.len then begin
+      t.bstr <- Bstr.create (2 * Bstr.length bstr);
+      Bstr.blit bstr ~src_off:t.off t.bstr ~dst_off:0 ~len:t.len
+    end;
+    let n = fn t.bstr ~off ~len:(Bstr.length t.bstr - off) in
+    t.len <- t.len + n;
+    n
+end
+
+module Notify = struct
+  type 'a t =
+    { queue : 'a Queue.t
+    ; mutex : Miou.Mutex.t
+    ; condition : Miou.Condition.t }
+
+  let create () =
+    { queue= Queue.create ()
+    ; mutex= Miou.Mutex.create ()
+    ; condition= Miou.Condition.create () }
+
+  let signal value t =
+    (* Miou.Mutex.protect t.mutex @@ fun () -> *)
+    Queue.push value t.queue;
+    Miou.Condition.signal t.condition
+
+  let await t =
+    Miou.Mutex.protect t.mutex @@ fun () ->
+    while Queue.is_empty t.queue do
+      Miou.Condition.wait t.condition t.mutex
+    done;
+    Queue.pop t.queue
+end
+
+(* NOTE(dinosaure): μTCP is actually well-abstracted about IPv4 and IPv6 but we
+   only have IPv4 implementation. We should handle easily the IPv6 at this
+   layer I think. *)
+module TCPv4 = struct
+  let src = Logs.Src.create "tcpv4"
+
+  module Log = (val Logs.src_log src : Logs.LOG)
+
+  type w = (unit, [ `Eof | `Msg of string ]) result Notify.t
+
+  type state =
+    { mutable tcp : w Utcp.state
+    ; ipv4 : IPv4.t
+    ; udpv4 : UDPv4.state
+    ; queue : Utcp.output Queue.t
+    ; mutex : Miou.Mutex.t
+    ; condition : Miou.Condition.t
+    ; accept : (int, accept) Hashtbl.t }
+
+  and accept =
+    | Await of flow Miou.Computation.t
+    | Pending of flow Queue.t
+
+  and flow =
+    { state : state
+    ; src : Logs.src
+    ; flow : Utcp.flow
+    ; buffer : Buffer.t
+    ; mutable closed : bool }
+
+  let[@inline] now () =
+    let n = Miou_solo5.clock_monotonic () in
+    Mtime.of_uint64_ns (Int64.of_int n)
+
+  let write_ipv4 ipv4 (src, dst, seg) =
+    let len = Utcp.Segment.length seg in
+    Log.debug (fun m -> m "write-out %d byte(s) to %a" (20 (* ipv4 packet *) + len) Ipaddr.V4.pp dst);
+    let fn bstr =
+      let cs = Cstruct.of_bigarray bstr in
+      let src = Ipaddr.V4 src
+      and dst = Ipaddr.V4 dst in
+      Utcp.Segment.encode_and_checksum_into (now ()) cs ~src ~dst seg in
+    let pkt = IPv4.Writer.into ipv4 ~len fn in
+    match IPv4.write ipv4 ~src dst ~protocol:6 pkt with
+    | Ok () -> ()
+    | Error `Route_not_found ->
+        Log.err (fun m -> m "%a is unreachable" Ipaddr.V4.pp dst);
+        raise Net_unreach
+
+  let write_ip ipv4 (src, dst, seg) =
+    match src, dst with
+    | Ipaddr.V4 src, Ipaddr.V4 dst -> write_ipv4 ipv4 (src, dst, seg)
+    | _ -> failwith "IPv6 not implemented"
+
+  type result =
+    | Filled
+    | Eof
+    | Refused
+
+  let fill t data =
+    let rec go data =
+      let { Cstruct.buffer; off; len } = data in
+      if len > 0 then begin
+        let len = Int.min len (Buffer.available t.buffer) in
+        let fn dst ~off:dst_off ~len:_ =
+          Bstr.blit buffer ~src_off:off dst ~dst_off ~len; len in
+        let _ = Buffer.put t.buffer ~fn in
+        go (Cstruct.shift data len)
+      end in
+    go data; Filled
+
+  let read_into t =
+    match Utcp.recv t.state.tcp (now ()) t.flow with
+    | Ok (tcp, data, c, segs) ->
+        t.state.tcp <- tcp;
+        List.iter (write_ip t.state.ipv4) segs;
+        Logs.debug ~src:t.src (fun m -> m "recv new packet (%d byte(s))"
+          (Cstruct.length data));
+        if Cstruct.length data == 0
+        then match Notify.await c with
+        | Ok () ->
+            begin match Utcp.recv t.state.tcp (now ()) t.flow with
+            | Ok (tcp, data, _c, segs) ->
+                (* TODO(dinosaure): assert (c == _c)? *)
+                t.state.tcp <- tcp;
+                List.iter (write_ip t.state.ipv4) segs;
+                Logs.debug ~src:t.src (fun m -> m "recv new packet (%d byte(s)) (second)"
+                  (Cstruct.length data));
+                if Cstruct.length data == 0
+                then Eof else fill t data
+            | Error `Not_found -> Refused
+            | Error `Eof -> Eof
+            | Error (`Msg msg) ->
+                Logs.err ~src:t.src (fun m -> m "%a error while read (second recv): %s"
+                  Utcp.pp_flow t.flow msg);
+                Refused end
+        | Error `Eof -> Eof
+        | Error (`Msg msg) ->
+            Logs.err ~src:t.src (fun m -> m "%a error from computation while recv: %s"
+              Utcp.pp_flow t.flow msg);
+            Refused
+        else fill t data
+    | Error `Eof -> Eof
+    | Error (`Msg msg) ->
+        Logs.err ~src:t.src (fun m -> m "%a error while read: %s"
+          Utcp.pp_flow t.flow msg);
+        Refused
+    | Error `Not_found -> Refused
+
+  let read t ?off:(dst_off= 0) ?len buf =
+    if t.closed then 0
+    else
+      let len = match len with
+        | Some len -> len
+        | None -> Bytes.length buf - dst_off in
+      let fn bstr ~off:src_off ~len:src_len =
+        let len = Int.min src_len len in
+        Bstr.blit_to_bytes bstr ~src_off buf ~dst_off ~len; len in
+      if Buffer.length t.buffer > 0
+      then Buffer.get t.buffer ~fn
+      else match read_into t with
+      | Filled -> Buffer.get t.buffer ~fn
+      | Eof ->
+          Logs.debug ~src:t.src (fun m -> m "End-of-transmision received");
+          0
+      | Refused ->
+          Logs.err ~src:t.src (fun m -> m "Connection refused");
+          t.closed <- true; 0
+
+  let rec really_read t off len buf =
+    let len' = read t ~off ~len buf in
+    if len' == 0 then raise End_of_file
+    else if len - len' > 0 then
+      really_read t (off + len') (len - len') buf
+
+  let really_read t ?(off= 0) ?len buf =
+    let len = match len with None -> Bytes.length buf - off | Some len -> len in
+    if off < 0 || len < 0 || off > Bytes.length buf - len
+    then invalid_arg "TCPv4.really_read";
+    if len > 0 then really_read t off len buf
+
+  (* NOTE(dinosaure): μTCP takes the ownership on [cs], so we can not use a
+     internal buffer associated to our flow to avoid allocation-per-writing. The
+     only viable solution seems to modify μTCP to use strings instead of
+     [Cstruct.t]... *)
+  let rec write t cs =
+    match Utcp.send t.state.tcp (now ()) t.flow cs with
+    | Error `Not_found -> raise Connection_refused
+    | Error (`Msg msg) ->
+        Logs.err ~src:t.src (fun m -> m "%a error while write: %s"
+          Utcp.pp_flow t.flow msg);
+        raise Closed_by_peer
+    | Ok (tcp, bytes_sent, c, segs) ->
+        t.state.tcp <- tcp;
+        List.iter (write_ip t.state.ipv4) segs;
+        Logs.debug ~src:t.src (fun m -> m "write %d byte(s)" bytes_sent);
+        if bytes_sent < Cstruct.length cs
+        then
+          let result = Notify.await c in
+          match result with
+          | Error `Eof -> raise Closed_by_peer
+          | Error (`Msg msg) ->
+              Logs.err ~src:t.src (fun m -> m "%a error from condition while sending: %s"
+                Utcp.pp_flow t.flow msg);
+              raise Closed_by_peer
+          | Ok () ->
+              let cs = Cstruct.shift cs bytes_sent in
+              if Cstruct.length cs > 0 then write t (Cstruct.shift cs bytes_sent)
+              else Logs.debug ~src:t.src (fun m -> m "fully write the given string to peer")
+
+  let write t ?(off= 0) ?len str =
+    let len = match len with
+      | Some len -> len
+      | None -> String.length str - off in
+    write t (Cstruct.of_string ~off ~len str)
+
+  let close t =
+    if t.closed then Fmt.invalid_arg "Connection already closed";
+    match Utcp.close t.state.tcp (now ()) t.flow with
+    | Ok (tcp, segs) ->
+        t.state.tcp <- tcp;
+        List.iter (write_ip t.state.ipv4) segs;
+        t.closed <- true
+    | Error `Not_found -> ()
+    | Error (`Msg msg) ->
+        Logs.err ~src:t.src (fun m -> m "%a error in close: %s"
+          Utcp.pp_flow t.flow msg)
+
+  let peers { flow; _ } = Utcp.peers flow
+
+  let _eof = Error `Eof
+  let _ok = Ok ()
+
+  let handler state (pkt, payload) =
+    let src = Ipaddr.V4 pkt.IPv4.src in
+    let dst = Ipaddr.V4 pkt.IPv4.dst in
+    Log.debug (fun m -> m "New TCPv4 packet (%a -> %a)" Ipaddr.pp src Ipaddr.pp dst);
+    (* NOTE(dinosaure): μTCP takes the ownership on [cs] also. We can try to
+       think, a bit deeply, about a zero-copy which includes the TCP layer if
+       the given packet is not a part of a _segment_ but it requires some work
+       on the μTCP side. Also, μTCP works with [mirage-tcpip] because
+       [mirage-net-solo5] copies frames — which is not the case here! At least,
+       we make the copy as far as possible.
+
+       RE-NOTE(dinosaure): the viewer can say that we also do the copy for
+       ARPv4 and ICMPv4 but they are not a part of our "happy-path". What we
+       want to improve is the TCP/IP stack. ARPv4 & ICMPv4 are just side
+       protocols. *)
+    let cs = match payload with
+      | IPv4.Slice slice ->
+          let { Slice.buf; off; len; } = slice in
+          let bstr = Bstr.copy buf in
+          Cstruct.of_bigarray ~off ~len bstr
+      | IPv4.String str -> Cstruct.of_string str in
+    let tcp, ev, segs = Utcp.handle_buf state.tcp (now ()) ~src ~dst cs in
+    state.tcp <- tcp;
+    let none = ()
+    and some = function
+      | `Established (flow, None) ->
+          let (_, src_port), (ipaddr, port) = Utcp.peers flow in
+          Log.debug (fun m -> m "established connection with %a:%d"
+            Ipaddr.pp ipaddr port);
+          let src = Logs.Src.create (Fmt.str "%a:%d" Ipaddr.pp ipaddr port) in
+          let buffer = Buffer.create 0x7ff in
+          let flow = { state; src; flow; buffer; closed= false } in
+          begin match Hashtbl.find state.accept src_port with
+          | Await c ->
+              Hashtbl.remove state.accept src_port;
+              Log.debug (fun m -> m "transmit the new incoming TCPv4 connection to the handler");
+              ignore (Miou.Computation.try_return c flow)
+          | Pending q -> Queue.push flow q
+          | exception Not_found ->
+              let q = Queue.create () in
+              Queue.push flow q;
+              Hashtbl.add state.accept src_port (Pending q) end
+      | `Established (flow, Some c) ->
+          Log.debug (fun m -> m "connection established (%a)" Utcp.pp_flow flow);
+          Notify.signal _ok c
+      | `Drop (flow, c, cs) ->
+          Log.debug (fun m -> m "drop (%a)" Utcp.pp_flow flow);
+          List.iter (Notify.signal _eof) cs;
+          Option.iter (Notify.signal _ok) c
+      | `Signal (flow, cs) ->
+          Log.debug (fun m -> m "signal (%a)(%d)" Utcp.pp_flow flow (List.length cs));
+          List.iter (Notify.signal _ok) cs in
+    Option.fold ~none ~some ev;
+    Logs.debug (fun m -> m "%d segment(s) produced" (List.length segs));
+    List.iter (fun out -> Queue.push out state.queue) segs
+
+  let rec transfer state acc = match Queue.pop state.queue with
+    | exception Queue.Empty -> acc
+    | out -> transfer state (out :: acc)
+
+  let rec daemon state n =
+    let handler's_outs = transfer state [] in
+    let tcp, drops, outs = Utcp.timer state.tcp (now ()) in
+    state.tcp <- tcp;
+    let outs = List.rev_append handler's_outs outs in
+    let fn out =
+      Log.debug (fun m -> m "write new TCPv4 packet from daemon");
+      try write_ip state.ipv4 out
+      with
+      | Net_unreach ->
+        let (_, dst, _) = out in
+        Log.err (fun m -> m "Network unreachable for %a" Ipaddr.pp dst)
+      | exn ->
+        let (src, dst, _) = out in
+        Log.err (fun m -> m "Unexpected exception (%a -> %a): %s"
+          Ipaddr.pp src Ipaddr.pp dst (Printexc.to_string exn)) in
+    List.iter fn outs;
+    let fn (_id, err, rcv, snd) =
+      let err = match err with
+        | `Retransmission_exceeded -> `Msg "retransmission exceeded"
+        | `Timer_2msl -> `Eof
+        | `Timer_connection_established -> `Eof
+        | `Timer_fin_wait_2 -> `Eof in
+      let err = Error err in
+      Notify.signal err rcv;
+      Notify.signal err snd in
+    List.iter fn drops;
+    Miou_solo5.sleep 100_000_000;
+    daemon state (n+1)
+
+  type listen = Listen of int [@@unboxed]
+
+  let accept state (Listen port) =
+    match Hashtbl.find state.accept port with
+    | exception Not_found ->
+        let c = Miou.Computation.create () in
+        Hashtbl.add state.accept port (Await c);
+        Miou.Computation.await_exn c
+    | Await c ->
+        Log.debug (fun m -> m "listen on %a:%d: multiple waiters"
+          Ipaddr.V4.pp (IPv4.src state.ipv4) port);
+        Miou.Computation.await_exn c
+    | Pending q -> match Queue.pop q with
+      | exception Queue.Empty ->
+          let c = Miou.Computation.create () in
+          Hashtbl.replace state.accept port (Await c);
+          Miou.Computation.await_exn c
+      | flow -> flow
+
+  let listen state port =
+    let tcp = Utcp.start_listen state.tcp port in
+    state.tcp <- tcp;
+    Listen port
+
+  type daemon = unit Miou.t
+
+  let create ~name ipv4 =
+    let tcp = Utcp.empty Notify.create name Mirage_crypto_rng.generate in
+    let mutex = Miou.Mutex.create () in
+    let condition = Miou.Condition.create () in
+    let accept = Hashtbl.create 0x10 in
+    let udpv4 = UDPv4.create ipv4 in
+    let state = { tcp; ipv4; udpv4; queue= Queue.create (); mutex; condition; accept } in
+    let prm = Miou.async (fun () -> daemon state 0) in
+    prm, state
+
+  let kill = Miou.cancel
+
+  let connect state (dst, dst_port) =
+    let src = Ipaddr.V4 (IPv4.src state.ipv4) in
+    let dst = Ipaddr.V4 dst in
+    let tcp, flow, c, seg = Utcp.connect ~src ~dst ~dst_port state.tcp (now ()) in
+    let src = Logs.Src.create (Fmt.str "%a:%d" Ipaddr.pp dst dst_port) in
+    state.tcp <- tcp;
+    write_ip state.ipv4 seg;
+    Logs.debug ~src (fun m -> m "Waiting for a TCP handshake");
+    match Notify.await c with
+    | Ok () ->
+        let buffer = Buffer.create 0x7ff in
+        { state; flow; src; buffer; closed= false }
+    | Error `Eof ->
+        Logs.err ~src (fun m -> m "%a error established connection (timeout)" Utcp.pp_flow flow);
+        raise Connection_refused
+    | Error (`Msg msg) ->
+        Logs.err ~src (fun m -> m "%a error established connection: %s" Utcp.pp_flow flow msg);
+        raise Connection_refused
+
+  let udpv4 { udpv4; _ } = udpv4
+end
+
+let pp_error ppf = function
+  | `MTU_too_small -> Fmt.string ppf "MTU too small"
+  | `Exn exn -> Fmt.pf ppf "exception: %s" (Printexc.to_string exn)
+
+let ethernet_handler arpv4 ipv4 = ();
+  (* NOTE(dinosaure): about the handler and the packet received. The latter is
+     in the form of a [Bstr.t] that physically corresponds to the [Bstr.t] used
+     by Solo5. So to speak, from Solo5 to this [handler], there is no copy
+     and the [Bstr.t] given is exclusive to the current task. However, as soon
+     as this task is finished or would like to interact with the scheduler (and
+     produce an effect), the guarantee of exclusivity is no longer assured.
+
+     Depending on what you want to do, it may or may not be necessary to make a
+     copy of this [Bstr.t].
+
+     Currently, we can recognize a "happy-path" focus on TCP/IP. That is to say
+     that upon receipt of a TCP/IP packet, we would like to go as far as
+     possible without interruptions (like [Miou.yield] or any effects) to the
+     TCP layer. In this case, the IPv4 handler has no effect, it just tries to
+     reassemble packets it can depending on whether they are fragmented or not.
+     In short, the happy path corresponds to the moment when IPv4 returns a
+     packet in the form of a [Bstr.t] — that is to say that we have just
+     obtained a non-fragmented and complete packet and this packet still
+     physically corresponds to the one written by Solo5. Otherwise, [IPv4]
+     returns a packet in the form of a [string] which means that it has been
+     fragmented.
+
+     This choice to return 2 types of payloads corresponds to a simple split: it
+     is expensive to copy a [Bstr.t]. If we were to copy the [Bstr.t] given by
+     [Ethernet], it is always more worthwhile to finally transform it into a
+     [string] rather than "pretending that we still have a [Bstr.t]" underneath.
+     This distinction also clarifies another point: ownership. If you are
+     manipulating a [Bstr.t], you have to pay close attention to ownership and
+     always consider this "happy path" (without interruptions). Otherwise, you
+     can just manipulate the strings without asking yourself this question. *)
+  let handler pkt =
+    match pkt.Ethernet.protocol with
+    | Ethernet.ARPv4 -> ARPv4.transfer arpv4 pkt
+    | Ethernet.IPv4 -> IPv4.input ipv4 pkt
+    | _ -> () in
+  handler
+
+let ipv4_handler icmpv4 udpv4 tcpv4 = (); fun ((hdr, _) as pkt) ->
+  match hdr.IPv4.protocol with
+  | 1 -> ICMPv4.transfer icmpv4 pkt
+  | 6 -> TCPv4.handler tcpv4 pkt
+  | 17 -> UDPv4.handler udpv4 pkt
+  | _ -> ()
+
+type tcpv4 =
+  { ethernet_daemon : Ethernet.daemon
+  ; arpv4_daemon : ARPv4.daemon
+  ; icmpv4 : ICMPv4.daemon
+  ; udpv4 : UDPv4.state
+  ; tcpv4_daemon : TCPv4.daemon }
+
+let kill t =
+  TCPv4.kill t.tcpv4_daemon;
+  ICMPv4.kill t.icmpv4;
+  ARPv4.kill t.arpv4_daemon;
+  Ethernet.kill t.ethernet_daemon
+
+let tcpv4 ~name ?gateway cidr =
+  let fn (net, cfg) () =
+    let connect mac =
+      let ( let* ) = Result.bind in
+      let* daemon, eth = Ethernet.create ~mtu:cfg.Miou_solo5.Net.mtu mac net in
+      Logs.debug (fun m -> m "✓ ethernet plugged (%a)" Macaddr.pp (Ethernet.mac eth));
+      let* arpv4_daemon, arpv4 = ARPv4.create ~ipaddr:(Ipaddr.V4.Prefix.address cidr) eth in
+      Logs.debug (fun m -> m "✓ ARPv4 daemon launched");
+      let* ipv4 = IPv4.create eth arpv4 ?gateway cidr in
+      Logs.debug (fun m -> m "✓ IPv4 stack created");
+      let icmpv4 = ICMPv4.handler ipv4 in
+      Logs.debug (fun m -> m "✓ ICMPv4 daemon launched");
+      let tcpv4_daemon, tcpv4 = TCPv4.create ~name:"uniker.ml" ipv4 in
+      let udpv4 = TCPv4.udpv4 tcpv4 in
+      Logs.debug (fun m -> m "✓ TCPv4 daemon launched");
+      IPv4.set_handler ipv4 (ipv4_handler icmpv4 udpv4 tcpv4);
+      let fn = ethernet_handler arpv4 ipv4 in
+      Ethernet.set_handler eth fn;
+      Ok ({ ethernet_daemon= daemon; arpv4_daemon; udpv4; icmpv4; tcpv4_daemon }, tcpv4) in
+    let mac = Macaddr.of_octets_exn (cfg.Miou_solo5.Net.mac :> string) in
+    match connect mac with
+    | Ok daemon -> daemon
+    | Error err -> Fmt.failwith "%a" pp_error err in
+  Miou_solo5.(map fn [ net name ])

--- a/miou-solo5/utcp_miou_solo5.mli
+++ b/miou-solo5/utcp_miou_solo5.mli
@@ -1,0 +1,42 @@
+module Ethernet = Ethernet_miou_solo5
+module ARPv4 = Arp_miou_solo5
+module IPv4 = Ipv4_miou_solo5
+module ICMPv4 = Icmpv4_miou_solo5
+module UDPv4 = Udpv4_miou_solo5
+
+exception Net_unreach
+exception Closed_by_peer
+exception Connection_refused
+
+module TCPv4 : sig
+  type state
+  type flow
+  type daemon
+
+  val handler : state -> IPv4.packet * IPv4.payload -> unit
+  val create : name:string -> IPv4.t -> daemon * state
+  val kill : daemon -> unit
+
+  val connect : state -> (Ipaddr.V4.t * int) -> flow
+  val read : flow -> ?off:int -> ?len:int -> bytes -> int
+  val really_read : flow -> ?off:int -> ?len:int -> bytes -> unit
+  val write : flow -> ?off:int -> ?len:int -> string -> unit
+  val close : flow -> unit
+  val peers : flow -> (Ipaddr.t * int) * (Ipaddr.t * int)
+
+  type listen
+
+  val listen : state -> int -> listen
+  val accept : state -> listen -> flow
+  val udpv4 : state -> UDPv4.state
+end
+
+type tcpv4
+
+val tcpv4 :
+     name:string
+  -> ?gateway:Ipaddr.V4.t
+  -> Ipaddr.V4.Prefix.t
+  -> (tcpv4  * TCPv4.state) Miou_solo5.arg
+
+val kill : tcpv4 -> unit

--- a/utcp-miou-solo5.opam
+++ b/utcp-miou-solo5.opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/utcp"
+dev-repo: "git+https://github.com/robur-coop/utcp.git"
+bug-reports: "https://github.com/robur-coop/utcp/issues"
+available: [ arch != "arm32" & arch != "x86_32" ] # see #35
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "utcp" {= version}
+  "dune" {>= "2.7.0"}
+  "bstr"
+  "bin"
+  "miou-solo5"
+  "hxd"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An implementation of TCP (Transmission Control Protocol) in OCaml for Miou & Solo5"


### PR DESCRIPTION
This PR is a draft about the new TCP/IP stack (only IPv4 at this time) with `miou-solo5`. We reach the step where we can communicate with an unikernel but few issues still exist. Also, some benchmarks are required but it permits to have a global view about the implementation. As expected, it's just an addition. The actual workflow is to track bugs and improve `utcp` with this implementation (and do some tests) and patch-back `utcp` to some other PRs (as I did recently).