### PR TITLE
Possible optimisation when we receive a packet and we would like to compute `fin_trimmed`

### DIFF
--- a/src/input.ml
+++ b/src/input.ml
@@ -653,10 +653,7 @@ let di3_datastuff_really now the_ststuff conn seg _bsd_fast_path ourfinisacked f
     Cstruct.sub data_trimmed_left 0 (Int.min cb.rcv_wnd (Cstruct.length data_trimmed_left))
   in
   let fin_trimmed =
-    if Cstruct.length data_trimmed_left_right == Cstruct.length data_trimmed_left then
-      fin
-    else
-      false
+    fin && Cstruct.length data_trimmed_left_right == Cstruct.length data_trimmed_left
   in
   (*: Build trimmed segment to place on reassembly queue.  If urgent data is in
      this segment and the socket is not doing inline delivery (and hence the


### PR DESCRIPTION
I'm really not sure about this patch but it seems that that the goal is not to compare the content of the data but mainly if something is left between `data_trimmed_left` and `data_trimmed_left_right` (and the second comes from the first). Instead to use `Cstruct.equal` which involves `memcmp` (which has a serious cost), it should be preferable to compare only lengths of them.