### PR TITLE
Serialize a connection to a string and use this "flat" value as the index into our connections map

### DIFF
--- a/src/segment.ml
+++ b/src/segment.ml
@@ -209,7 +209,7 @@ let ws t =
 
 (* we always take our IP as source, thus of_segment -- to be used for a
    received segment -- needs to swap *)
-let to_id ~src ~dst t = (dst, t.dst_port, src, t.src_port)
+let to_id ~src ~dst t = State.Connection.v (dst, t.dst_port, src, t.src_port)
 
 let pp ppf t =
   Fmt.pf ppf "%a%s@ seq %a@ ack %a@ window %d@ opts %a, %d bytes data"
@@ -609,8 +609,9 @@ let encode_and_checksum_into now buf ~src ~dst t =
   encode_into buf t;
   let checksum = checksum ~src ~dst buf in
   Cstruct.BE.set_uint16 buf 16 checksum;
+  let id = State.Connection.v (src, t.src_port, dst, t.dst_port) in
   State.Tracing.debug (fun m -> m "%a [%a] out %u %s"
-                          State.Connection.pp (src, t.src_port, dst, t.dst_port)
+                          State.Connection.pp id 
                           Mtime.pp now (Cstruct.length t.payload)
                           (Base64.encode_string (Cstruct.to_string buf)))
 

--- a/src/tcptimer.ml
+++ b/src/tcptimer.ml
@@ -12,7 +12,7 @@ let timer_tt_rexmtsyn m now shift id conn =
   | Syn_sent (* simultaneous open (deliver_in_2b) may put us into Syn_received *) ->
     if succ shift > Params.tcp_maxrxtshift then begin
       Log.debug (fun m -> m "%a syn retransmission reached maxrxtshift, dropping" Connection.pp id);
-      let rst = Segment.drop_and_close id conn in
+      let rst = Segment.drop_and_close (Connection.prj id) conn in
       Error `Retransmission_exceeded, rst
     end else
       let cb = conn.control_block in
@@ -37,7 +37,7 @@ let timer_tt_rexmtsyn m now shift id conn =
       in
       let conn' = { conn with control_block } in
       Log.debug (fun m -> m "%a retransmitting syn %a" Connection.pp id (pp_conn_state now) conn');
-      Ok conn', Some (Segment.make_syn control_block id)
+      Ok conn', Some (Segment.make_syn control_block (Connection.prj id))
   | _ ->
     Log.warn (fun m -> m "%a rexmtsyn timer, not in syn_sent state %a"
                 Connection.pp id (pp_conn_state now) conn);
@@ -55,7 +55,7 @@ let timer_tt_rexmt m now shift id conn =
     let maxshift = match tcp_state with Syn_received -> Params.tcp_synackmaxrxtshift | _ -> Params.tcp_maxrxtshift in
     if succ shift > maxshift then begin
       Log.debug (fun m -> m "%a retransmission reached maxrxtshift, dropping" Connection.pp id);
-      let rst = Segment.drop_and_close id conn in
+      let rst = Segment.drop_and_close (Connection.prj id) conn in
       Error `Retransmission_exceeded, rst
     end else
       let snd_cwnd_prev, snd_ssthresh_prev = (* , t_badrxtwin *)
@@ -83,8 +83,8 @@ let timer_tt_rexmt m now shift id conn =
       } in
       let conn' = { conn with control_block } in
       let c', out = match tcp_state with
-        | Syn_received -> conn', Segment.make_syn_ack control_block id
-        | _ -> Segment.tcp_output_really now id false conn'
+        | Syn_received -> conn', Segment.make_syn_ack control_block (Connection.prj id)
+        | _ -> Segment.tcp_output_really now (Connection.prj id) false conn'
       in
       Ok c', Some out
 
@@ -116,7 +116,7 @@ let fast_timer t now =
         | Some timer -> match Timers.timer_expired now timer with
           | None -> CM.add id conn acc, outs
           | Some () ->
-            let c', out = timer_tt_delack m now id conn in
+            let c', out = timer_tt_delack m now (Connection.prj id) conn in
             CM.add id c' acc, out :: outs)
       t.connections (CM.empty, [])
   in
@@ -147,7 +147,7 @@ let slow_timer t now =
           | Some (Persist, shift), _, _, _ ->
             Log.debug (fun m -> m "%a persist timer expired %a" Connection.pp id (pp_conn_state now) conn);
             (* it's easy: restart and tcp_output_really! *)
-            timer_tt_persist m now shift id conn
+            timer_tt_persist m now shift (Connection.prj id) conn
           | None, Some (), _, _ ->
             (* timer_tt_2msl_1 *)
             Log.debug (fun m -> m "%a 2msl timer expired %a" Connection.pp id (pp_conn_state now) conn);
@@ -159,7 +159,7 @@ let slow_timer t now =
             Log.debug (fun m -> m "%a connection established timer expired %a" Connection.pp id (pp_conn_state now) conn);
             if not (conn.tcp_state = Syn_sent) then Log.err (fun m -> m "not in syn_sent");
             m "timer-tt-conn-est";
-            Error `Timer_connection_established, Segment.drop_and_close id conn
+            Error `Timer_connection_established, Segment.drop_and_close (Connection.prj id) conn
           | None, None, None, Some () ->
             (* timer_tt_fin_wait_2_1 *)
             Log.debug (fun m -> m "%a fin_wait_2 timer expired %a" Connection.pp id (pp_conn_state now) conn);

--- a/src/utcp.ml
+++ b/src/utcp.ml
@@ -9,8 +9,10 @@ let stop_listen = State.stop_listen
 type flow = State.Connection.t
 
 let pp_flow = State.Connection.pp
+let unsafe_flow = State.Connection.v
 
-let peers (src, src_port, dst, dst_port) =
+let peers conn =
+  let (src, src_port, dst, dst_port) = State.Connection.prj conn in
   (src, src_port), (dst, dst_port)
 
 type output = Ipaddr.t * Ipaddr.t * Segment.t

--- a/src/utcp.mli
+++ b/src/utcp.mli
@@ -226,3 +226,4 @@ end
 
 module Checksum = Checksum
 (**/**)
+val unsafe_flow : Ipaddr.t * int * Ipaddr.t * int -> flow

--- a/test/state_machine.ml
+++ b/test/state_machine.ml
@@ -143,7 +143,7 @@ and your_ip = Ipaddr.(V4 (V4.of_string_exn "1.2.3.5"))
 and listen_port = 1234
 and src_port = 4321
 
-let quad = Obj.magic (my_ip, listen_port, your_ip, src_port)
+let quad = Utcp.unsafe_flow (my_ip, listen_port, your_ip, src_port)
 
 (* a TCP stack listening on port 1234 *)
 let tcp = State.empty Fun.id "" static_rng


### PR DESCRIPTION
The comparison between strings is better than a comparison between ipaddrs and ports. This patch redefine `Connection.t`/`Utcp.flow` and "flat" the identifier to a string to be able to use only String.compare when it's about searching or adding a new connection.

This PR is not well benchmarked but I noticed a huge usage of `Ipaddr.compare` and with this PR, this usage disappears. It can raise another question, we probably can use `art` also which is much more fast for such kind of keys (but it's another question).