### PR TITLE
Use `string` instead of `Cstruct.t`

### DIFF
--- a/app/single.ml
+++ b/app/single.ml
@@ -46,12 +46,13 @@ let jump _ src src_port dst dst_port syn fin rst push ack seq window data =
         | false, false, false -> None
         | _ -> invalid_arg "invalid flag combination"
       and ack = match ack with None -> None | Some x -> Some (Sequence.of_int32 (Int32.of_int x))
-      and payload = match data with None -> Cstruct.empty | Some x -> Cstruct.of_string x
-      in
+      and payload = match data with None -> Cstruct.empty | Some x -> Cstruct.of_string x in
+      let payload_len = Cstruct.length payload in
+      let payload = [ payload ] in
       let s = {
         src_port ; dst_port ;
         seq = Sequence.of_int32 (Int32.of_int seq) ;
-        ack ; flag ; push ; window ; options = [] ; payload
+        ack ; flag ; push ; window ; options = [] ; payload_len ; payload
       } in
       encode_and_checksum (Mtime_clock.now ()) ~src:Ipaddr.(V4 (V4.Prefix.address cidr)) ~dst s
     in

--- a/src/input.ml
+++ b/src/input.ml
@@ -640,7 +640,7 @@ let di3_datastuff_really now the_ststuff conn seg _bsd_fast_path ourfinisacked f
     else
       0
   in
-  let data_trimmed_left = Rope.of_css seg.payload in
+  let data_trimmed_left = Rope.of_strings seg.payload in
   let data_trimmed_left = Rope.shift data_trimmed_left trim_amt_left in
   let seq_trimmed = Sequence.addi seg.seq trim_amt_left in
   (*: Trimmed data starts at [[seq_trimmed]] :*)

--- a/src/input.ml
+++ b/src/input.ml
@@ -241,7 +241,7 @@ let in_window cb seg =
   let seq = seg.Segment.seq
   and max = Sequence.addi cb.rcv_nxt cb.rcv_wnd
   in
-  match Cstruct.length seg.Segment.payload, cb.rcv_wnd with
+  match seg.Segment.payload_len, cb.rcv_wnd with
   | 0, 0 -> Sequence.equal seq cb.rcv_nxt
   | 0, _ -> Sequence.less_equal cb.rcv_nxt seq && Sequence.less seq max
   | _, 0 -> false
@@ -415,7 +415,7 @@ let di3_newackstuff now id conn ourfinisacked ack =
         (*: If this socket has previously emitted a [[FIN]] segment and the
            [[FIN]] has now been [[ACK]]ed, decrease [[snd_wnd]] by the length of
            the send queue and clear the send queue.:*)
-        cb.snd_wnd - Cstruct.lenv conn.sndq, []
+        cb.snd_wnd - Rope.length conn.sndq, Rope.empty
       else
         (*: Otherwise, reduce the send window by the amound of data acknowledged
            as it is now consuming space on the receiver's receive queue. Remove
@@ -423,7 +423,7 @@ let di3_newackstuff now id conn ourfinisacked ack =
            be retransmitted.:*)
         let acked = Sequence.window ack cb.snd_una in
         cb.snd_wnd - acked,
-        List.rev (Cstruct.shiftv (List.rev conn.sndq) acked)
+        Rope.shift conn.sndq acked
     in
     (*: Update the control block :*)
     let cb' =
@@ -510,7 +510,7 @@ let di3_ackstuff now id conn seg ourfinisacked fin ack =
      from the other end, these may all contain the same acknowledgement number
      and trigger the retransmit logic erroneously. :*)
   let maybe_dup_ack =
-    Cstruct.length seg.payload = 0 && win = cb.snd_wnd &&
+    seg.payload_len = 0 && win = cb.snd_wnd &&
     match cb.tt_rexmt with Some ((Rexmt, _), _) -> true | _ -> false
   in
   (* It turns out since some time the first FIN(+ACK) doesn't account for
@@ -636,11 +636,12 @@ let di3_datastuff_really now the_ststuff conn seg _bsd_fast_path ourfinisacked f
      urgent data in the segment. :*)
   let trim_amt_left =
     if Sequence.greater cb.rcv_nxt seg.Segment.seq then
-      Int.min (Sequence.window cb.rcv_nxt seg.seq) (Cstruct.length seg.payload)
+      Int.min (Sequence.window cb.rcv_nxt seg.seq) seg.payload_len
     else
       0
   in
-  let data_trimmed_left = Cstruct.shift seg.payload trim_amt_left in
+  let data_trimmed_left = Rope.of_css seg.payload in
+  let data_trimmed_left = Rope.shift data_trimmed_left trim_amt_left in
   let seq_trimmed = Sequence.addi seg.seq trim_amt_left in
   (*: Trimmed data starts at [[seq_trimmed]] :*)
   (*: Trim any data outside the receive window from the right hand edge. If all
@@ -650,10 +651,11 @@ let di3_datastuff_really now the_ststuff conn seg _bsd_fast_path ourfinisacked f
      here because there is still urgent data to be received, but now in a future
      segment. :*)
   let data_trimmed_left_right =
-    Cstruct.sub data_trimmed_left 0 (Int.min cb.rcv_wnd (Cstruct.length data_trimmed_left))
+    let len = Int.min cb.rcv_wnd (Rope.length data_trimmed_left) in
+    Rope.sub data_trimmed_left ~off:0 ~len
   in
   let fin_trimmed =
-    if Cstruct.equal data_trimmed_left_right data_trimmed_left then
+    if Rope.length data_trimmed_left_right = Rope.length data_trimmed_left then
       fin
     else
       false
@@ -675,7 +677,7 @@ let di3_datastuff_really now the_ststuff conn seg _bsd_fast_path ourfinisacked f
      the conditions below. :*)
   let rseq_trimmed =
     Sequence.addi seq_trimmed
-      (Cstruct.length data_trimmed_left_right + (if fin_trimmed then 1 else 0))
+      (Rope.length data_trimmed_left_right + (if fin_trimmed then 1 else 0))
   in
   let (conn', fin_reass, out), cont =
     if
@@ -686,7 +688,7 @@ let di3_datastuff_really now the_ststuff conn seg _bsd_fast_path ourfinisacked f
       (*: Only need to acknowledge the segment if there is new in-window data
          (including urgent data) or a valid [[FIN]] :*)
       let have_stuff_to_ack =
-        Cstruct.length data_trimmed_left_right > 0 || fin_trimmed
+        Rope.length data_trimmed_left_right > 0 || fin_trimmed
       in
       (*: If the socket is connected, has data to [[ACK]] but no [[FIN]] to
          [[ACK]], the reassembly queue is empty, the socket is not currently
@@ -703,10 +705,10 @@ let di3_datastuff_really now the_ststuff conn seg _bsd_fast_path ourfinisacked f
       let t_segq, r = Reassembly_queue.maybe_take cb.t_segq rseq_trimmed in
       (* Length (in sequence space) of reassembled data, counting a [[FIN]] as
          one byte and including any out-of-line urgent data previously removed *)
-      let data_reass, fin_reass0 = Option.value ~default:(Cstruct.empty, false) r in
-      let data = Cstruct.append data_trimmed_left_right data_reass in
+      let data_reass, fin_reass0 = Option.value ~default:(Rope.empty, false) r in
+      let data = Rope.concat data_trimmed_left_right data_reass in
       let fin_reass_trimmed = fin_trimmed || fin_reass0 in
-      let data_len = Cstruct.length data + if fin_reass_trimmed then 1 else 0 in
+      let data_len = Rope.length data + if fin_reass_trimmed then 1 else 0 in
      (*: Add the reassembled data to the receive queue and increment [[rcv_nxt]]
         to mark the sequence number of the byte past the last byte in the
         receive queue:*)
@@ -726,7 +728,7 @@ let di3_datastuff_really now the_ststuff conn seg _bsd_fast_path ourfinisacked f
         (*: Set if not delaying an [[ACK]] and have stuff to [[ACK]] :*)
         not delay_ack && have_stuff_to_ack
       and rcv_nxt = Sequence.addi cb.rcv_nxt data_len
-      and rcv_wnd = cb.rcv_wnd - (Cstruct.length data)
+      and rcv_wnd = cb.rcv_wnd - (Rope.length data)
       in
       let control_block = {
         cb with
@@ -736,7 +738,7 @@ let di3_datastuff_really now the_ststuff conn seg _bsd_fast_path ourfinisacked f
         rcv_nxt ;
         rcv_wnd ;
       }
-      and rcvq = data :: conn.rcvq
+      and rcvq = Rope.concat conn.rcvq data
       in
       ({ conn with control_block ; rcvq }, fin_reass_trimmed, []), true
      (*: Case (2) The segment contains new out-of-order in-window data, possibly
@@ -746,7 +748,7 @@ let di3_datastuff_really now the_ststuff conn seg _bsd_fast_path ourfinisacked f
     else if
       Sequence.greater seq_trimmed cb.rcv_nxt &&
       Sequence.less seq_trimmed (Sequence.addi cb.rcv_nxt cb.rcv_wnd) &&
-      Cstruct.length data_trimmed_left_right + (if fin_trimmed then 1 else 0) > 0 &&
+      Rope.length data_trimmed_left_right + (if fin_trimmed then 1 else 0) > 0 &&
       cb.rcv_wnd > 0
     then
       (*: Hack: assertion used to share values with later conditions :*)
@@ -765,7 +767,7 @@ let di3_datastuff_really now the_ststuff conn seg _bsd_fast_path ourfinisacked f
          segment) is used in the guard to ensure this really was a pure [[ACK]]
          segment. :*)
     else if Sequence.equal seq_trimmed cb.rcv_nxt &&
-            Cstruct.length seg.payload + (if fin then 1 else 0) = 0
+            seg.payload_len + (if fin then 1 else 0) = 0
     then
       (*: Hack: assertion used to share values with later conditions :*)
       let fin_reass = false in (* Have not received a FIN *)
@@ -826,7 +828,7 @@ let di3_datastuff now the_ststuff conn seg ourfinisacked fin ack =
     ((Sequence.greater ack cb.snd_una && Sequence.less_equal ack cb.snd_max &&
       cb.snd_cwnd >= cb.snd_wnd && cb.t_dupacks < 3)
      || (Sequence.equal ack cb.snd_una && Reassembly_queue.is_empty cb.t_segq &&
-         Cstruct.length seg.payload < conn.rcvbufsize - Cstruct.lenv conn.rcvq))
+         seg.payload_len < conn.rcvbufsize - Rope.length conn.rcvq))
   in
   (*: Update the send window using the received segment if the segment will not be processed by
       BSD's fast path, has the [[ACK]] flag set, is not to the right of the window, and either:
@@ -849,7 +851,7 @@ let di3_datastuff now the_ststuff conn seg ourfinisacked fin ack =
       (Sequence.less cb.snd_wl2 ack || Sequence.equal cb.snd_wl2 ack && win > cb.snd_wnd)))
   in
   let seq_trimmed =
-    Sequence.max seg.seq (Sequence.min cb.rcv_nxt (Sequence.addi seg.seq (Cstruct.length seg.payload)))
+    Sequence.max seg.seq (Sequence.min cb.rcv_nxt (Sequence.addi seg.seq seg.payload_len))
   in
   (*: Write back the window updates :*)
   let control_block =
@@ -926,7 +928,7 @@ let deliver_in_3 m now id conn seg flag ack =
   let fin = flag = Some `Fin in
   (* PAWS, timers, rcv_wnd may have opened! updates fin_wait_2 timer *)
   let cb = conn.control_block in
-  let wesentafin = Sequence.greater cb.snd_max (Sequence.addi cb.snd_una (Cstruct.lenv conn.sndq)) in
+  let wesentafin = Sequence.greater cb.snd_max (Sequence.addi cb.snd_una (Rope.length conn.sndq)) in
   let ourfinisacked = wesentafin && Sequence.greater_equal ack cb.snd_max in
   let control_block = di3_topstuff now conn in
   (* ACK processing *)
@@ -1063,7 +1065,7 @@ let handle_conn t now id conn seg =
       let* () =
         guard (in_window conn.control_block seg)
           (`Drop (fun () -> Fmt.str "in_window seq %a seql %u rcv_nxt %a rcv_wnd %u"
-                     Sequence.pp seg.Segment.seq (Cstruct.length seg.payload)
+                     Sequence.pp seg.Segment.seq seg.payload_len
                      Sequence.pp conn.control_block.rcv_nxt conn.control_block.rcv_wnd))
       in
       (* RFC5961: challenge acks for SYN and (RST where seq != rcv_nxt), keep state *)
@@ -1112,7 +1114,7 @@ let handle_buf t now ~src ~dst data =
   | Ok (seg, id) ->
     Tracing.debug (fun m -> m "%a [%a] handle_buf %u %s"
                       Connection.pp id Mtime.pp now
-                      (Cstruct.length seg.payload)
+                      seg.payload_len
                       (Base64.encode_string (Cstruct.to_string data)));
     (* deliver_in_3a deliver_in_4 are done now! *)
     let t', outs = handle_segment t now id seg in
@@ -1128,8 +1130,8 @@ let handle_buf t now ~src ~dst data =
         | Some s ->
           s.tcp_state = Established,
           true,
-          Cstruct.lenv s.rcvq > 0,
-          Cstruct.lenv s.sndq < s.sndbufsize,
+          Rope.length s.rcvq > 0,
+          Rope.length s.sndq < s.sndbufsize,
           Some s.rcv_notify, Some s.snd_notify
       in
       match was_established, is_established, was_present, is_present with

--- a/src/rope.ml
+++ b/src/rope.ml
@@ -33,7 +33,7 @@ let sub t ~off ~len =
   let stop = off + len in
   if off < 0 || len < 0 || stop > length t
   then invalid_arg "Rope.sub";
-  if len == 0 then t else sub t off stop
+  if len == 0 then empty else sub t off stop
 
 let shift t len = sub t ~off:len ~len:(length t - len)
 

--- a/src/rope.ml
+++ b/src/rope.ml
@@ -1,0 +1,86 @@
+type t =
+  | Str of Cstruct.t * int * int
+  | App of t * t * int * int
+
+let length = function
+  | Str (_, _, len)
+  | App (_, _, len, _) -> len
+
+let empty = Str (Cstruct.empty, 0, 0)
+
+let height = function
+  | Str _ -> 0
+  | App (_, _, _, h) -> h
+
+let append = function
+  | Str (_,_,0), t | t, Str (_,_,0) ->  t
+  | t1, t2 -> 
+      App (t1, t2, length t1 + length t2, 1 + Int.max (height t1) (height t2))
+
+
+let rec sub t start stop =
+  if start == 0 && stop = length t
+  then t else match t with
+    | Str (str, off, _) ->
+        Str (str, off + start, stop - start)
+    | App (l, r, _, _) ->
+        let len = length l in
+        if stop <= len then sub l start stop
+        else if start >= len then sub r (start - len) (stop - len)
+        else append (sub l start len, sub r 0 (stop - len))
+
+let sub t ~off ~len =
+  let stop = off + len in
+  if off < 0 || len < 0 || stop > length t
+  then invalid_arg "Rope.sub";
+  if len == 0 then t else sub t off stop
+
+let shift t len = sub t ~off:len ~len:(length t - len)
+
+let rec into_bytes buf dst_off = function
+  | Str (cs, src_off, len) -> Cstruct.blit_to_bytes cs src_off buf dst_off len
+  | App (l, r, _, _) ->
+    into_bytes buf dst_off l;
+    into_bytes buf (dst_off + length l) r
+
+let to_css t =
+  let rec go acc = function
+    | Str (_, _, 0) | Str ({ Cstruct.len= 0; _ }, _, _) -> acc
+    | Str ({ Cstruct.len= rlen; _ } as cs, 0, len) ->
+        if rlen == len then cs :: acc
+        else Cstruct.sub cs 0 len :: acc
+    | Str (cs, off, len) ->
+        Cstruct.sub cs off len :: acc
+    | App (l, r, _, _) -> go (go acc r) l in
+  go [] t
+
+let to_cs t =
+  let buf = Cstruct.create (length t) in
+  let rec go dst_off = function
+    | Str (_, _, 0) | Str ({ Cstruct.len= 0; _ }, _, _) -> ()
+    | Str (cs, src_off, len) -> Cstruct.blit cs src_off buf dst_off len
+    | App (l, r, _, _) ->
+        go dst_off l;
+        go (dst_off + length l) r in
+  go 0 t; buf
+
+let to_string t =
+  let len = length t in
+  let buf = Bytes.create len in
+  into_bytes buf 0 t;
+  Bytes.unsafe_to_string buf
+
+let concat a b = append (a, b)
+let prepend ({ Cstruct.len; _ } as cs) t = append (Str (cs, 0, len), t)
+
+let append t ?(off= 0) ?len ({ Cstruct.len= rlen; _ } as cs) =
+  let len = match len with
+    | Some len -> len | None -> rlen - off in
+  append (t, (Str (cs, off, len)))
+
+let of_cs ({ Cstruct.len; _ } as cs) = Str (cs, 0, len)
+let of_css css = List.fold_left (fun t cs -> append t cs) empty css
+let of_string str = of_cs (Cstruct.of_string str)
+
+let equal a b =
+  String.equal (to_string a) (to_string b)

--- a/src/rope.ml
+++ b/src/rope.ml
@@ -1,12 +1,12 @@
 type t =
-  | Str of Cstruct.t * int * int
+  | Str of string * int * int
   | App of t * t * int * int
 
 let length = function
   | Str (_, _, len)
   | App (_, _, len, _) -> len
 
-let empty = Str (Cstruct.empty, 0, 0)
+let empty = Str (String.empty, 0, 0)
 
 let height = function
   | Str _ -> 0
@@ -14,9 +14,29 @@ let height = function
 
 let append = function
   | Str (_,_,0), t | t, Str (_,_,0) ->  t
+  (* NOTE(dinosaure): we can coalesce strings and be sure that the allocation
+     still is localized into the minor heap or we can just keep chunks as they
+     are. We already to the fragmentation to small pieces of strings when we
+     pass from a [Cstruct.t] to some strings.
+
+  | Str (s1, ofs1, len1), Str (s2, ofs2, len2) when len1 + len2 <= 0x7ff ->
+      let buf = Bytes.create (len1 + len2) in
+      Bytes.blit_string s1 ofs1 buf 0 len1;
+      Bytes.blit_string s2 ofs2 buf len1 len2;
+      Str (Bytes.unsafe_to_string buf, 0, len1 + len2)
+  | App (t1, Str (s1, ofs1, len1), _, _), Str (s2, ofs2, len2) when len1 + len2 <= 0x7ff ->
+      let buf = Bytes.create (len1 + len2) in
+      Bytes.blit_string s1 ofs1 buf 0 len1;
+      Bytes.blit_string s2 ofs2 buf len1 len2;
+      App (t1, Str (Bytes.unsafe_to_string buf, 0, len1 + len2), length t1 + len1 + len2, 1 + height t1)
+  | Str (s1, ofs1, len1), App (Str (s2, ofs2, len2), t2, _, _) when len1 + len2 <= 0x7ff ->
+      let buf = Bytes.create (len1 + len2) in
+      Bytes.blit_string s1 ofs1 buf 0 len1;
+      Bytes.blit_string s2 ofs2 buf len1 len2;
+      App (Str (Bytes.unsafe_to_string buf, 0, len1 + len2), t2, len1 + len2 + length t2, 1 + height t2)
+  *)
   | t1, t2 -> 
       App (t1, t2, length t1 + length t2, 1 + Int.max (height t1) (height t2))
-
 
 let rec sub t start stop =
   if start == 0 && stop = length t
@@ -38,31 +58,18 @@ let sub t ~off ~len =
 let shift t len = sub t ~off:len ~len:(length t - len)
 
 let rec into_bytes buf dst_off = function
-  | Str (cs, src_off, len) -> Cstruct.blit_to_bytes cs src_off buf dst_off len
+  | Str (str, src_off, len) -> Bytes.blit_string str src_off buf dst_off len
   | App (l, r, _, _) ->
     into_bytes buf dst_off l;
     into_bytes buf (dst_off + length l) r
 
-let to_css t =
+let to_strings t =
   let rec go acc = function
-    | Str (_, _, 0) | Str ({ Cstruct.len= 0; _ }, _, _) -> acc
-    | Str ({ Cstruct.len= rlen; _ } as cs, 0, len) ->
-        if rlen == len then cs :: acc
-        else Cstruct.sub cs 0 len :: acc
-    | Str (cs, off, len) ->
-        Cstruct.sub cs off len :: acc
+    | Str (_, _, 0) -> acc
+    | Str (str, 0, len) when String.length str == len -> str :: acc
+    | Str (str, off, len) -> String.sub str off len :: acc
     | App (l, r, _, _) -> go (go acc r) l in
   go [] t
-
-let to_cs t =
-  let buf = Cstruct.create (length t) in
-  let rec go dst_off = function
-    | Str (_, _, 0) | Str ({ Cstruct.len= 0; _ }, _, _) -> ()
-    | Str (cs, src_off, len) -> Cstruct.blit cs src_off buf dst_off len
-    | App (l, r, _, _) ->
-        go dst_off l;
-        go (dst_off + length l) r in
-  go 0 t; buf
 
 let to_string t =
   let len = length t in
@@ -71,16 +78,13 @@ let to_string t =
   Bytes.unsafe_to_string buf
 
 let concat a b = append (a, b)
-let prepend ({ Cstruct.len; _ } as cs) t = append (Str (cs, 0, len), t)
+let prepend str t = append (Str (str, 0, String.length str), t)
 
-let append t ?(off= 0) ?len ({ Cstruct.len= rlen; _ } as cs) =
+let append t ?(off= 0) ?len str =
   let len = match len with
-    | Some len -> len | None -> rlen - off in
-  append (t, (Str (cs, off, len)))
+    | Some len -> len | None -> String.length str - off in
+  append (t, (Str (str, off, len)))
 
-let of_cs ({ Cstruct.len; _ } as cs) = Str (cs, 0, len)
-let of_css css = List.fold_left (fun t cs -> append t cs) empty css
-let of_string str = of_cs (Cstruct.of_string str)
-
-let equal a b =
-  String.equal (to_string a) (to_string b)
+let of_string str = Str (str, 0, String.length str)
+let of_strings strs = List.fold_left (fun t str -> append t str) empty strs
+let equal a b = String.equal (to_string a) (to_string b)

--- a/src/segment.ml
+++ b/src/segment.ml
@@ -180,7 +180,8 @@ type t = {
   push : bool ;
   window : int ;
   options : tcp_option list ;
-  payload : Cstruct.t ;
+  payload : Cstruct.t list ;
+  payload_len : int ;
 }
 
 let equal a b =
@@ -193,7 +194,7 @@ let equal a b =
   a.window = b.window &&
   List.length a.options = List.length b.options &&
   List.for_all2 equal_option a.options b.options &&
-  Cstruct.equal a.payload b.payload
+  Cstruct.(equal (concat a.payload) (concat b.payload))
 
 let max_win = 1 lsl 16 - 1
 
@@ -217,7 +218,7 @@ let pp ppf t =
     Sequence.pp t.seq
     Fmt.(option ~none:(any "no") Sequence.pp) t.ack
     t.window Fmt.(list ~sep:(any ";@ ") pp_option) t.options
-    (Cstruct.length t.payload)
+    t.payload_len
 
 let count_flags = function
   | Some (`Fin | `Syn) -> 1
@@ -228,7 +229,7 @@ let make_rst_from_cb cb (src, src_port, dst, dst_port) =
   src, dst,
   { src_port ; dst_port ; seq = cb.State.snd_nxt ; ack = Some cb.rcv_nxt ;
     flag = Some `Rst ; push = false ; window = 0 ; options = [] ;
-    payload = Cstruct.empty }
+    payload_len = 0 ; payload = [] }
 
 (* auxFns:2219 *)
 let dropwithreset seg =
@@ -240,7 +241,7 @@ let dropwithreset seg =
       | Some ack -> None, ack (* never ACK an ACK *)
       | None ->
         let ack =
-          let data_len = Cstruct.length seg.payload
+          let data_len = seg.payload_len
           and flag_len = count_flags seg.flag
           in
           Sequence.(addi (addi seg.seq data_len) flag_len)
@@ -251,7 +252,8 @@ let dropwithreset seg =
            dst_port = seg.src_port ;
            seq ; ack ;
            flag = Some `Rst ; push = false ;
-           window = 0 ; options = [] ; payload = Cstruct.empty }
+           window = 0 ; options = [] ;
+           payload_len = 0 ; payload = [] }
 
 (* auxFns:2331 *)
 let drop_and_close id conn =
@@ -288,7 +290,7 @@ let tcp_output_required now conn =
       effectively still have a [[SYN]] on the send queue. :*)
   let syn_not_acked = match conn.State.tcp_state with Syn_sent | Syn_received -> true | _ -> false in
   (*: Is there data or a FIN to transmit? :*)
-  let last_sndq_data_seq = Sequence.addi cb.State.snd_una (Cstruct.lenv conn.State.sndq) in
+  let last_sndq_data_seq = Sequence.addi cb.State.snd_una (Rope.length conn.State.sndq) in
   let last_sndq_data_and_fin_seq =
     Sequence.(addi (addi last_sndq_data_seq (if fin_required then 1 else 0))
                 (if syn_not_acked then 1 else 0))
@@ -298,7 +300,7 @@ let tcp_output_required now conn =
   (*: The amount by which the right edge of the advertised window could be moved :*)
   let window_update_delta =
     (Int.min (Params.tcp_maxwin lsl cb.State.rcv_scale))
-       (conn.rcvbufsize - Cstruct.lenv conn.rcvq) -
+       (conn.rcvbufsize - Rope.length conn.rcvq) -
     Sequence.window cb.State.rcv_adv cb.State.rcv_nxt
   in
   (*: Send a window update? This occurs when (a) the advertised window can be increased by at
@@ -320,7 +322,7 @@ let tcp_output_required now conn =
     cb.State.tf_shouldacknow
   in
   let persist_fun =
-    let cant_send = not do_output && Cstruct.lenv conn.sndq = 0 && cb.State.tt_rexmt = None in
+    let cant_send = not do_output && Rope.length conn.sndq = 0 && cb.State.tt_rexmt = None in
     let window_shrunk = win = 0 && snd_wnd_unused < 0 in  (*: [[win = 0]] if in [[SYN_SENT]], but still may send FIN :*)
                                                      (* (bsd_arch arch ==> tcp_sock.st <> SYN_SENT)) in *)
     if cant_send then  (* takes priority over window_shrunk; note this needs to be checked *)
@@ -370,23 +372,24 @@ let tcp_output_really_helper now (src, src_port, dst, dst_port) window_probe con
     conn.State.cantsndmore &&
     match conn.State.tcp_state with State.Fin_wait_2 | State.Time_wait -> false | _ -> true
   in
-  let last_sndq_data_seq = Sequence.addi cb.State.snd_una (Cstruct.lenv conn.sndq) in
+  let last_sndq_data_seq = Sequence.addi cb.State.snd_una (Rope.length conn.sndq) in
   (*: The data to send in this segment (if any) :*)
   let data_to_send, more_data_could_be_sent =
     let data' =
-      Cstruct.shiftv (List.rev conn.State.sndq)
+      Rope.shift conn.State.sndq
         (Int.max 0
-           (Int.min (Cstruct.lenv conn.State.sndq)
+           (Int.min (Rope.length conn.State.sndq)
               (Sequence.window cb.State.snd_nxt cb.State.snd_una)))
         (* taking the minimum to avoid exceeding the sndq *)
     in
-    let data' = Cstruct.concat data' in
+    let dlen = Rope.length data' in
     let len_could_be_sent = Int.max 0 snd_wnd_unused in
-    let dlen = Cstruct.length data' in
-    Cstruct.sub data' 0 (Int.min dlen (Int.min len_could_be_sent cb.State.t_maxseg)),
-    dlen > cb.t_maxseg && len_could_be_sent > cb.t_maxseg
+    let data' =
+      let len = Int.min dlen (Int.min len_could_be_sent cb.State.t_maxseg) in
+      Rope.sub data' ~off:0 ~len in
+    data', dlen > cb.t_maxseg && len_could_be_sent > cb.t_maxseg
   in
-  let dlen = Cstruct.length data_to_send in
+  let dlen = Rope.length data_to_send in
   (*: Should [[FIN]] be set in this segment? :*)
   let fin = fin_required && Sequence.(greater_equal (addi cb.State.snd_nxt dlen) last_sndq_data_seq) in
   (*: If this socket has previously sent a [[FIN]] which has not yet been acked, and [[snd_nxt]]
@@ -425,7 +428,8 @@ let tcp_output_really_helper now (src, src_port, dst, dst_port) window_probe con
     { src_port ; dst_port ; seq = snd_nxt;
       ack = Some cb.State.rcv_nxt ; flag ; push ;
       window = Int.min (rcv_wnd' lsr cb.rcv_scale) max_win ;
-      options = [] ; payload = data_to_send
+      options = [] ; payload_len= Rope.length data_to_send ;
+      payload = Rope.to_css data_to_send
     }
   in
   (*: If emitting a [[FIN]] for the first time then change TCP state :*)
@@ -533,7 +537,7 @@ let make_syn_ack cb (src, src_port, dst, dst_port) =
   src, dst,
   { src_port ; dst_port ; seq = cb.iss ; ack = Some cb.rcv_nxt ;
     flag = Some `Syn ; push = false ; window ; options ;
-    payload = Cstruct.empty }
+    payload_len = 0 ; payload = [] }
 
 (* auxFns:1333 *)
 let make_syn cb (src, src_port, dst, dst_port) =
@@ -545,7 +549,7 @@ let make_syn cb (src, src_port, dst, dst_port) =
   src, dst,
   { src_port ; dst_port ; seq = cb.State.iss ; ack = None ;
     flag = Some `Syn ; push = false ;
-    window ; options ; payload = Cstruct.empty }
+    window ; options ; payload_len = 0 ; payload = [] }
 
 (* auxFns:1437 *)
 let make_ack cb ~fin (src, src_port, dst, dst_port) =
@@ -556,7 +560,8 @@ let make_ack cb ~fin (src, src_port, dst, dst_port) =
     seq = if fin then cb.snd_una else cb.snd_nxt ;
     ack = Some cb.rcv_nxt ;
     flag = if fin then Some `Fin else None ;
-    push = false ; window ; options = [] ; payload = Cstruct.empty }
+    push = false ; window ; options = [] ;
+    payload_len = 0 ; payload = [] }
 
 let checksum ~src ~dst cs =
   let len = Cstruct.length cs in
@@ -595,10 +600,14 @@ let encode_into buf t =
   Cstruct.set_uint8 buf 13 (Flag.encode ((match t.ack with None -> false | Some _ -> true), t.flag, t.push));
   Cstruct.BE.set_uint16 buf 14 t.window;
   let _ = encode_options buf 20 t.options in
-  Cstruct.blit t.payload 0 buf (20 + opt_len) (Cstruct.length t.payload)
+  let rec go dst_off = function
+    | [] -> ()
+    | { Cstruct.len; _ } as x :: r ->
+        Cstruct.blit x 0 buf dst_off len; go (dst_off + len) r in
+  go (20 + opt_len) t.payload
 
 let length t =
-  header_size + Cstruct.length t.payload + length_options t.options
+  header_size + t.payload_len + length_options t.options
 
 let encode t =
   let buf = Cstruct.create (length t) in
@@ -611,7 +620,7 @@ let encode_and_checksum_into now buf ~src ~dst t =
   Cstruct.BE.set_uint16 buf 16 checksum;
   State.Tracing.debug (fun m -> m "%a [%a] out %u %s"
                           State.Connection.pp (src, t.src_port, dst, t.dst_port)
-                          Mtime.pp now (Cstruct.length t.payload)
+                          Mtime.pp now t.payload_len
                           (Base64.encode_string (Cstruct.to_string buf)))
 
 let encode_and_checksum now ~src ~dst t =
@@ -638,8 +647,10 @@ let decode data =
   let options_buf = Cstruct.sub data header_size (data_off - header_size) in
   let* options = decode_options options_buf in
   let payload = Cstruct.shift data data_off in
+  let payload_len = Cstruct.length payload in
+  let payload = [ payload ] in
   let ack = if ackf then Some ack else None in
-  Ok ({ src_port; dst_port; seq; ack; flag; push; window; options; payload },
+  Ok ({ src_port; dst_port; seq; ack; flag; push; window; options; payload_len; payload },
       checksum)
 
 let decode_and_validate ~src ~dst data =

--- a/src/segment.ml
+++ b/src/segment.ml
@@ -180,7 +180,7 @@ type t = {
   push : bool ;
   window : int ;
   options : tcp_option list ;
-  payload : Cstruct.t list ;
+  payload : string list ;
   payload_len : int ;
 }
 
@@ -194,7 +194,7 @@ let equal a b =
   a.window = b.window &&
   List.length a.options = List.length b.options &&
   List.for_all2 equal_option a.options b.options &&
-  Cstruct.(equal (concat a.payload) (concat b.payload))
+  String.(equal (concat "" a.payload) (concat "" b.payload))
 
 let max_win = 1 lsl 16 - 1
 
@@ -429,7 +429,7 @@ let tcp_output_really_helper now (src, src_port, dst, dst_port) window_probe con
       ack = Some cb.State.rcv_nxt ; flag ; push ;
       window = Int.min (rcv_wnd' lsr cb.rcv_scale) max_win ;
       options = [] ; payload_len= Rope.length data_to_send ;
-      payload = Rope.to_css data_to_send
+      payload = Rope.to_strings data_to_send
     }
   in
   (*: If emitting a [[FIN]] for the first time then change TCP state :*)
@@ -602,8 +602,9 @@ let encode_into buf t =
   let _ = encode_options buf 20 t.options in
   let rec go dst_off = function
     | [] -> ()
-    | { Cstruct.len; _ } as x :: r ->
-        Cstruct.blit x 0 buf dst_off len; go (dst_off + len) r in
+    | x :: r ->
+        let len = String.length x in
+        Cstruct.blit_from_string x 0 buf dst_off len; go (dst_off + len) r in
   go (20 + opt_len) t.payload
 
 let length t =
@@ -628,6 +629,22 @@ let encode_and_checksum now ~src ~dst t =
   encode_and_checksum_into now buf ~src ~dst t;
   buf
 
+(* NOTE(dinosaure): We would like the data to be located on the minor heap. For
+   this reason, to convert from [Cstruct.t] to strings, we fragment the data so
+   that each chunk can be allocated as quickly as possible (on the minor heap),
+   unlike allocation on the major heap, where data exceeding [0x7ff] bytes is
+   allocated. *)
+let to_chunks cs =
+  let rec go acc cs =
+    if Cstruct.length cs == 0 then List.rev acc
+    else begin
+      let len = Int.min 0x7ff (Cstruct.length cs) in
+      let buf = Bytes.create len in
+      Cstruct.blit_to_bytes cs 0 buf 0 len;
+      go (Bytes.unsafe_to_string buf :: acc) (Cstruct.shift cs len)
+    end in
+  go [] cs
+
 let decode data =
   let* () = guard (Cstruct.length data >= header_size) (`Msg "too small") in
   let src_port = Cstruct.BE.get_uint16 data 0
@@ -648,7 +665,7 @@ let decode data =
   let* options = decode_options options_buf in
   let payload = Cstruct.shift data data_off in
   let payload_len = Cstruct.length payload in
-  let payload = [ payload ] in
+  let payload = to_chunks payload in
   let ack = if ackf then Some ack else None in
   Ok ({ src_port; dst_port; seq; ack; flag; push; window; options; payload_len; payload },
       checksum)

--- a/src/state.ml
+++ b/src/state.ml
@@ -72,7 +72,7 @@ module Reassembly_queue = struct
   type reassembly_segment = {
     seq : Sequence.t ;
     fin : bool ;
-    data : Cstruct.t list ; (* in reverse order *)
+    data : Rope.t ; (* in reverse order *)
   }
 
   (* we take care that the list is sorted by the sequence number *)
@@ -85,12 +85,12 @@ module Reassembly_queue = struct
   let length t = List.length t
 
   let pp_rseg ppf { seq ; data ; _ } =
-    Fmt.pf ppf "%a (len %u)" Sequence.pp seq (Cstruct.lenv data)
+    Fmt.pf ppf "%a (len %u)" Sequence.pp seq (Rope.length data)
 
   let pp = Fmt.(list ~sep:(any ", ") pp_rseg)
 
   (* insert segment, potentially coalescing existing ones *)
-  let insert_seg t (seq, fin, data) =
+  let insert_seg t (seq, fin, (data : Rope.t)) =
     (* they may overlap, the newest seg wins *)
     (* (1) figure out the place whereafter to insert the seg *)
     (* (2) peek whether the next seg can be already coalesced *)
@@ -104,14 +104,14 @@ module Reassembly_queue = struct
               let overlap = Sequence.sub seq_end e.seq in
               if overlap = 0 then
                 (* overlap = 0, we can just merge them *)
-                let elt = { elt with fin = e.fin || elt.fin ; data = e.data @ elt.data } in
-                Some (elt, Sequence.addi elt.seq (Cstruct.lenv elt.data)), elt :: acc'
+                let elt = { elt with fin = e.fin || elt.fin ; data = Rope.concat elt.data e.data } in
+                Some (elt, Sequence.addi elt.seq (Rope.length elt.data)), elt :: acc'
               else
                 (* we need to cut some bytes from e *)
-                let data = List.rev (Cstruct.shiftv (List.rev e.data) overlap) in
-                let data = data @ elt.data in
+                let data = Rope.shift e.data overlap in
+                let data = Rope.concat elt.data data in
                 let elt = { elt with fin = e.fin || elt.fin ; data } in
-                Some (elt, Sequence.addi elt.seq (Cstruct.lenv data)), elt :: acc'
+                Some (elt, Sequence.addi elt.seq (Rope.length data)), elt :: acc'
             else
               (* there's still a hole, nothing to merge *)
               (inserted, e :: acc)
@@ -128,7 +128,7 @@ module Reassembly_queue = struct
             *)
             if Sequence.less_equal seq e.seq then
               (* case (a) *)
-              let seq_e = Sequence.addi seq (Cstruct.length data) in
+              let seq_e = Sequence.addi seq (Rope.length data) in
               (* case (1): a new segment that is way before the existing one:
                  seq <= e.seq && seq_e <= e.seq -> e must be retained
                  case (2): a new segment that is partially before the existing:
@@ -138,56 +138,46 @@ module Reassembly_queue = struct
               *)
               if Sequence.less_equal seq_e e.seq then
                 if Sequence.equal seq_e e.seq then
-                  let e = { seq ; fin = fin || e.fin ; data = e.data @ [ data ] } in
-                  Some (e, Sequence.addi seq (Cstruct.lenv e.data)), e :: acc
+                  let e = { seq ; fin = fin || e.fin ; data = Rope.concat data e.data } in
+                  Some (e, Sequence.addi seq (Rope.length e.data)), e :: acc
                 else
-                  let e' = { seq ; fin ; data = [ data ] } in
-                  Some (e', Sequence.addi seq (Cstruct.length data)), e :: e' :: acc
+                  let e' = { seq ; fin ; data } in
+                  Some (e', Sequence.addi seq (Rope.length data)), e :: e' :: acc
               else
-                let e_seq_e = Sequence.addi e.seq (Cstruct.lenv e.data) in
+                let e_seq_e = Sequence.addi e.seq (Rope.length e.data) in
                 if Sequence.greater_equal seq_e e_seq_e then
-                  let e' = { seq ; fin ; data = [ data ] } in
+                  let e' = { seq ; fin ; data } in
                   Some (e', seq_e), e' :: acc
                 else
                   (* we've to retain some parts of seq *)
                   let post =
                     let retain_data = Sequence.sub e_seq_e seq_e in
-                    let skip_data = Cstruct.lenv e.data - retain_data in
-                    Cstruct.shiftv (List.rev e.data) skip_data
+                    let skip_data = Rope.length e.data - retain_data in
+                    Rope.shift e.data skip_data
                   in
-                  let e = { seq ; fin = fin || e.fin ; data = List.rev (data :: post) } in
-                  Some (e, Sequence.addi seq (Cstruct.lenv e.data)), e :: acc
+                  let e = { seq ; fin = fin || e.fin ; data = Rope.concat data post } in
+                  Some (e, Sequence.addi seq (Rope.length e.data)), e :: acc
             else
-              let e_seq_e = Sequence.addi e.seq (Cstruct.lenv e.data) in
+              let e_seq_e = Sequence.addi e.seq (Rope.length e.data) in
               if Sequence.less_equal seq e_seq_e then
                 (* case (b) we append to the thing *)
                 if Sequence.equal seq e_seq_e then
-                  let e = { e with fin = fin || e.fin ; data = data :: e.data } in
-                  Some (e, Sequence.addi e_seq_e (Cstruct.length data)), e :: acc
+                  let e = { e with fin = fin || e.fin ; data = Rope.concat e.data data } in
+                  Some (e, Sequence.addi e_seq_e (Rope.length data)), e :: acc
                 else
                   let overlap = Sequence.sub e_seq_e seq in
-                  let pre =
-                    let rec cut_some amount = function
-                      | [] -> []
-                      | hd :: tl ->
-                        if Cstruct.length hd < amount then
-                          cut_some (amount - Cstruct.length hd) tl
-                        else
-                          Cstruct.sub hd amount (Cstruct.length hd - amount) :: tl
-                    in
-                    cut_some overlap e.data
-                  in
-                  let seq_e = Sequence.addi seq (Cstruct.length data) in
+                  let pre = Rope.sub e.data ~off:0 ~len:(Rope.length e.data - overlap) in
+                  let seq_e = Sequence.addi seq (Rope.length data) in
                   let end_ = Sequence.max e_seq_e seq_e in
                   let post =
                     if Sequence.greater e_seq_e seq_e then
                       let retain_data = Sequence.sub e_seq_e seq_e in
-                      let skip_data = Cstruct.lenv e.data - retain_data in
-                      Cstruct.shiftv (List.rev e.data) skip_data
+                      let skip_data = Rope.length e.data - retain_data in
+                      Rope.shift e.data skip_data
                     else
-                      []
+                      Rope.empty
                   in
-                  let e = { e with fin = fin || e.fin ; data = post @ data :: pre } in
+                  let e = { e with fin = fin || e.fin ; data = Rope.concat (Rope.concat pre data) post } in
                   Some (e, end_), e :: acc
               else
                 (None, e :: acc))
@@ -195,7 +185,7 @@ module Reassembly_queue = struct
     in
     let segq =
       if inserted = None then
-        { seq ; fin ; data = [ data ] } :: segq
+        { seq ; fin ; data } :: segq
       else
         segq
     in
@@ -207,13 +197,13 @@ module Reassembly_queue = struct
           match r with
           | None ->
             if Sequence.equal seq e.seq then
-              Some (Cstruct.concat (List.rev e.data), e.fin), acc
+              Some (e.data, e.fin), acc
             else if Sequence.greater seq e.seq then
-              let e_end = Sequence.addi e.seq (Cstruct.lenv e.data) in
+              let e_end = Sequence.addi e.seq (Rope.length e.data) in
               if Sequence.less seq e_end then
                 let to_cut = Sequence.sub seq e.seq in
-                let data = Cstruct.concat (List.rev e.data) in
-                Some (Cstruct.shift data to_cut, e.fin), acc
+                let data = Rope.shift e.data to_cut in
+                Some (data, e.fin), acc
               else
                 None, acc
             else
@@ -441,8 +431,8 @@ type 'a conn_state = {
   cantsndmore : bool ;
   rcvbufsize : int ;
   sndbufsize : int ;
-  rcvq : Cstruct.t list ; (* reverse of the received data *)
-  sndq : Cstruct.t list ; (* reverse list of data to be sent out *)
+  rcvq : Rope.t ; (* reverse of the received data *)
+  sndq : Rope.t ; (* reverse list of data to be sent out *)
   rcv_notify : 'a;
   snd_notify : 'a;
   created : Mtime.t;
@@ -451,7 +441,7 @@ type 'a conn_state = {
 let conn_state created mk_notify ~rcvbufsize ~sndbufsize tcp_state control_block = {
   tcp_state ; control_block ;
   cantrcvmore = false ; cantsndmore = false ;
-  rcvq = [] ; sndq = [] ;
+  rcvq = Rope.empty ; sndq = Rope.empty ;
   rcvbufsize ; sndbufsize ;
   rcv_notify = mk_notify () ; snd_notify = mk_notify () ;
   created ;
@@ -524,8 +514,8 @@ let metrics () =
       CM.fold (fun k conn (rcvq, sndq, acc) ->
           if Mtime.(Span.to_uint64_ns (span now conn.created)) > Duration.of_min 1 then
             Log.info (fun m -> m "%a in %a" Connection.pp k (pp_conn_state now) conn);
-          rcvq + Cstruct.lenv conn.rcvq,
-          sndq + Cstruct.lenv conn.sndq,
+          rcvq + Rope.length conn.rcvq,
+          sndq + Rope.length conn.sndq,
           States.update conn.tcp_state (fun v -> Some (succ (Option.value ~default:0 v))) acc)
         connections
         (0, 0, States.empty)

--- a/src/subr.ml
+++ b/src/subr.ml
@@ -72,7 +72,7 @@ let calculate_buf_sizes (* conn *) cb_t_maxseg seg_mss bw_delay_product_for_rt r
 
 let calculate_bsd_rcv_wnd conn =
   Int.max (Sequence.window conn.control_block.rcv_adv conn.control_block.rcv_nxt)
-    (conn.rcvbufsize - Cstruct.lenv conn.rcvq)
+    (conn.rcvbufsize - Rope.length conn.rcvq)
 
 let update_rtt rtt ri =
   let rtt = Mtime.Span.to_uint64_ns rtt in

--- a/src/utcp.ml
+++ b/src/utcp.ml
@@ -42,3 +42,5 @@ module Input = Input
 module User = User
 
 module Checksum = Checksum
+
+module Rope = Rope

--- a/src/utcp.mli
+++ b/src/utcp.mli
@@ -54,7 +54,8 @@ module Segment : sig
     push : bool ;
     window : int ;
     options : tcp_option list ;
-    payload : Cstruct.t ;
+    payload : Cstruct.t list ;
+    payload_len : int ;
   }
 
   val pp : t Fmt.t
@@ -96,7 +97,7 @@ val shutdown : 'a state -> Mtime.t -> flow -> [ `read | `write | `read_write ] -
   ('a state * output list, [ `Not_found | `Msg of string ]) result
 
 val recv : 'a state -> Mtime.t -> flow ->
-  ('a state * Cstruct.t * 'a * output list, [ `Not_found | `Msg of string | `Eof ]) result
+  ('a state * Cstruct.t list * 'a * output list, [ `Not_found | `Msg of string | `Eof ]) result
 
 val send : 'a state -> Mtime.t -> flow -> Cstruct.t ->
   ('a state * int * 'a * output list, [ `Not_found | `Msg of string ]) result
@@ -134,8 +135,8 @@ module State : sig
     val empty : t
     val is_empty : t -> bool
     val length : t -> int
-    val insert_seg : t -> (Sequence.t * bool * Cstruct.t) -> t
-    val maybe_take : t -> Sequence.t -> (t * (Cstruct.t * bool) option)
+    val insert_seg : t -> (Sequence.t * bool * Rope.t) -> t
+    val maybe_take : t -> Sequence.t -> (t * (Rope.t * bool) option)
     val pp : t Fmt.t
   end
   type control_block = {
@@ -186,8 +187,8 @@ module State : sig
     cantsndmore : bool ;
     rcvbufsize : int ;
     sndbufsize : int ;
-    rcvq : Cstruct.t list ;
-    sndq : Cstruct.t list ;
+    rcvq : Rope.t ;
+    sndq : Rope.t ;
     rcv_notify : 'a;
     snd_notify : 'a;
     created : Mtime.t;
@@ -225,4 +226,5 @@ module User : sig
 end
 
 module Checksum = Checksum
+module Rope = Rope
 (**/**)

--- a/src/utcp.mli
+++ b/src/utcp.mli
@@ -54,7 +54,7 @@ module Segment : sig
     push : bool ;
     window : int ;
     options : tcp_option list ;
-    payload : Cstruct.t list ;
+    payload : string list ;
     payload_len : int ;
   }
 
@@ -97,9 +97,9 @@ val shutdown : 'a state -> Mtime.t -> flow -> [ `read | `write | `read_write ] -
   ('a state * output list, [ `Not_found | `Msg of string ]) result
 
 val recv : 'a state -> Mtime.t -> flow ->
-  ('a state * Cstruct.t list * 'a * output list, [ `Not_found | `Msg of string | `Eof ]) result
+  ('a state * string list * 'a * output list, [ `Not_found | `Msg of string | `Eof ]) result
 
-val send : 'a state -> Mtime.t -> flow -> Cstruct.t ->
+val send : 'a state -> Mtime.t -> flow -> ?off:int -> ?len:int -> string ->
   ('a state * int * 'a * output list, [ `Not_found | `Msg of string ]) result
 
 (**/**)

--- a/test/checksum.ml
+++ b/test/checksum.ml
@@ -7,52 +7,57 @@ let simple () =
   let t =
     Segment.{ src_port = 10 ; dst_port = 100 ; seq = Sequence.zero ;
               ack = None ; flag = None ; push = false ; window = 10 ;
-              options = [] ; payload = Cstruct.empty }
+              options = [] ; payload_len = 0 ; payload = [] }
   in
   Alcotest.(check int "simple" 39786 Segment.(checksum ~src ~dst (encode t)))
 
 let data1 () =
   let payload = Cstruct.of_hex "01" in
+  let payload_len = Cstruct.length payload in
   let t =
     Segment.{ src_port = 10 ; dst_port = 100 ; seq = Sequence.zero ;
               ack = None ; flag = None ; push = false ; window = 10 ;
-              options = [] ; payload }
+              options = [] ; payload_len ; payload = [ payload ] }
   in
   Alcotest.(check int "data1" 39529 Segment.(checksum ~src ~dst (encode t)))
 
 let data2 () =
   let payload = Cstruct.of_hex "01 02" in
+  let payload_len = Cstruct.length payload in
   let t =
     Segment.{ src_port = 10 ; dst_port = 100 ; seq = Sequence.zero ;
               ack = None ; flag = None ; push = false ; window = 10 ;
-              options = [] ; payload }
+              options = [] ; payload_len ; payload = [ payload ] }
   in
   Alcotest.(check int "data2" 39526 Segment.(checksum ~src ~dst (encode t)))
 
 let data3 () =
   let payload = Cstruct.of_hex "01 02 03" in
+  let payload_len = Cstruct.length payload in
   let t =
     Segment.{ src_port = 10 ; dst_port = 100 ; seq = Sequence.zero ;
               ack = None ; flag = None ; push = false ; window = 10 ;
-              options = [] ; payload }
+              options = [] ; payload_len ; payload = [ payload ] }
   in
   Alcotest.(check int "data3" 38757 Segment.(checksum ~src ~dst (encode t)))
 
 let data4 () =
   let payload = Cstruct.of_hex "01 02 03 04" in
+  let payload_len = Cstruct.length payload in
   let t =
     Segment.{ src_port = 10 ; dst_port = 100 ; seq = Sequence.zero ;
               ack = None ; flag = None ; push = false ; window = 10 ;
-              options = [] ; payload }
+              options = [] ; payload_len ; payload = [ payload ] }
   in
   Alcotest.(check int "data4" 38752 Segment.(checksum ~src ~dst (encode t)))
 
 let data5 () =
   let payload = Cstruct.of_hex "01 02 03 04 05" in
+  let payload_len = Cstruct.length payload in
   let t =
     Segment.{ src_port = 10 ; dst_port = 100 ; seq = Sequence.zero ;
               ack = None ; flag = None ; push = false ; window = 10 ;
-              options = [] ; payload }
+              options = [] ; payload_len ; payload = [ payload ] }
   in
   Alcotest.(check int "data5" 37471 Segment.(checksum ~src ~dst (encode t)))
 


### PR DESCRIPTION
This PR adds only one commit on top of #54 which simplify a lot the diff. The really interesting commit is ec245d8. I did a benchmark to compare #54 and this PR and this is the results. The first benchmark is with #54 and the second is with this PR (`rope` + `string`):
```sh
$ iperf3 -c 10.0.0.2
Connecting to host 10.0.0.2, port 5201
[  6] local 10.0.0.1 port 53394 connected to 10.0.0.2 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  6]   0.00-1.00   sec   155 MBytes  1.30 Gbits/sec    0    178 KBytes       
[  6]   1.00-2.00   sec   162 MBytes  1.36 Gbits/sec    0    178 KBytes       
[  6]   2.00-3.00   sec   163 MBytes  1.37 Gbits/sec    0    178 KBytes       
[  6]   3.00-4.00   sec   166 MBytes  1.39 Gbits/sec    0    178 KBytes       
[  6]   4.00-5.00   sec   157 MBytes  1.32 Gbits/sec    0    178 KBytes       
[  6]   5.00-6.00   sec   166 MBytes  1.39 Gbits/sec    0    178 KBytes       
[  6]   6.00-7.00   sec   158 MBytes  1.33 Gbits/sec    0    178 KBytes       
[  6]   7.00-8.00   sec   166 MBytes  1.39 Gbits/sec    0    178 KBytes       
[  6]   8.00-9.00   sec   159 MBytes  1.33 Gbits/sec    0    178 KBytes       
[  6]   9.00-10.00  sec   163 MBytes  1.37 Gbits/sec    0    178 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  6]   0.00-10.00  sec  1.58 GBytes  1.35 Gbits/sec    0            sender
[  6]   0.00-10.00  sec  0.00 Bytes  0.00 bits/sec                  receiver

iperf Done.
$ iperf3 -c 10.0.0.2
Connecting to host 10.0.0.2, port 5201
[  6] local 10.0.0.1 port 52132 connected to 10.0.0.2 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  6]   0.00-1.00   sec   155 MBytes  1.30 Gbits/sec    0    178 KBytes       
[  6]   1.00-2.00   sec   165 MBytes  1.38 Gbits/sec    0    178 KBytes       
[  6]   2.00-3.00   sec   162 MBytes  1.36 Gbits/sec    0    178 KBytes       
[  6]   3.00-4.00   sec   167 MBytes  1.40 Gbits/sec    0    178 KBytes       
[  6]   4.00-5.00   sec   160 MBytes  1.34 Gbits/sec    0    178 KBytes       
[  6]   5.00-6.00   sec   167 MBytes  1.40 Gbits/sec    0    178 KBytes       
[  6]   6.00-7.00   sec   160 MBytes  1.34 Gbits/sec    0    178 KBytes       
[  6]   7.00-8.00   sec   166 MBytes  1.40 Gbits/sec    0    178 KBytes       
[  6]   8.00-9.00   sec   164 MBytes  1.38 Gbits/sec    0    178 KBytes       
[  6]   9.00-10.00  sec   161 MBytes  1.35 Gbits/sec    0    178 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  6]   0.00-10.00  sec  1.59 GBytes  1.36 Gbits/sec    0            sender
[  6]   0.00-10.00  sec  0.00 Bytes  0.00 bits/sec                  receiver

iperf Done.
```

As we can see, we don't have a big difference. However, the cool things is: on the second unikernel, only one and unique bigarray is allocated (and re-used) to read Ethernet frame. We don't have anymore bigarrays allocations (/cc @palainp). I can confirm that with `memtrace`. I tested with 128M and 5 calls to `iperf3` to see how the GC reacts when we have bigarrays and when we use `string`.

With `Cstruct.t` and `rope` (you can see **A** bigarray.ml):
<img width="1623" height="671" alt="screenshot" src="https://github.com/user-attachments/assets/1f439cab-4d10-4da1-b67d-bef35c393e2c" />

With `string` and `rope`:
<img width="1624" height="657" alt="screenshot" src="https://github.com/user-attachments/assets/e41a7315-f090-45e7-be30-54ae1eb725a8" />
