### PR TITLE
Add a function which attempts to send few bytes if it's possible without interacting with the scheduler

### DIFF
--- a/src/utcp.ml
+++ b/src/utcp.ml
@@ -28,6 +28,7 @@ let shutdown = User.shutdown
 let recv = User.recv
 
 let send = User.send
+let attempt_to_directly_send = User.attempt_to_directly_send
 
 module Segment = Segment
 

--- a/src/utcp.mli
+++ b/src/utcp.mli
@@ -102,6 +102,9 @@ val recv : 'a state -> Mtime.t -> flow ->
 val send : 'a state -> Mtime.t -> flow -> ?off:int -> ?len:int -> string ->
   ('a state * int * 'a * output list, [ `Not_found | `Msg of string ]) result
 
+val attempt_to_directly_send : 'a state -> Mtime.t -> flow -> ?off:int -> ?len:int -> string ->
+  ('a state * output list, [ `Not_enough_space | `Not_found | `Msg of string ]) result
+
 (**/**)
 (* only to be used for testing! *)
 module Timers : sig


### PR DESCRIPTION
This function allows you to attempt to write one (or more TCP/IP packets) without interruption. An interruption occurs if you want to write more than `conn.sndbufsize - Rope.length conn.sndq`. In this case, a `Not_enough_space` error is returned and the user is left to handle the situation.

Otherwise, the happy path is that we can add the bytes to our `conn.sndq` and produce one or more segments that can then be written without interruption.

The idea is to be able to implement a `Tls.close` function that would like to send a _close notify_ without any effect being performed and without any interruption.