### PR TITLE
Don't try to decode options when the packet is completely empty (reported by @kit-ty-kate)

### DIFF
--- a/src/segment.ml
+++ b/src/segment.ml
@@ -661,8 +661,10 @@ let decode data =
   let* () =
     guard (Cstruct.length data >= data_off) (`Msg "data_offset too big")
   in
-  let options_buf = Cstruct.sub data header_size (data_off - header_size) in
-  let* options = decode_options options_buf in
+  let* options =
+    if data_off - header_size > 0
+    then decode_options (Cstruct.sub data header_size (data_off - header_size))
+    else Ok [] (* no options *) in
   let payload = Cstruct.shift data data_off in
   let payload_len = Cstruct.length payload in
   let payload = to_chunks payload in


### PR DESCRIPTION
@kit-ty-kate reported a crash which comes from `utcp`. This is the trace:
```
console 2026-01-26T13:34:22-00:00: Fatal error: exception Invalid_argument("Cstruct.sub: [34,20](1514) off=20 len=-20")
console 2026-01-26T13:34:22-00:00: Raised at Stdlib.invalid_arg in file "[stdlib.ml](http://stdlib.ml/)", line 30, characters 20-45
console 2026-01-26T13:34:22-00:00: Called from Utcp__Segment.decode in file "duniverse/utcp/src/segment.ml", line 664, characters 20-73
```

From what I understand, we received an completely empty packet (no data, no options). This PR add a just a guard to ensure that we can `Cstruct.sub`. Otherwise, we returns an empty list of options.