### PR TITLE
Segment.decode: check data_off field to be at least 5 (so we have the 20 byte TCP header)

### DIFF
--- a/src/segment.ml
+++ b/src/segment.ml
@@ -653,6 +653,10 @@ let decode data =
   and ack = Sequence.of_int32 (Cstruct.BE.get_uint32 data 8)
   and data_off = (Cstruct.get_uint8 data 12 lsr 4) * 4 (* lower 4 are reserved [can't assume they're 0] *)
   in
+  let* () =
+    guard (data_off >= 5)
+      (`Msg ("data offset field must be greater than or equal to 5, but it is " ^ string_of_int data_off))
+  in
   let* ackf, flag, push = Flag.decode (Cstruct.get_uint8 data 13) in
   let window = Cstruct.BE.get_uint16 data 14
   and checksum = Cstruct.BE.get_uint16 data 16


### PR DESCRIPTION
alternative to #66 /cc @dinosaure 