### PR TITLE
Fix sequence number

### DIFF
--- a/src/sequence.ml
+++ b/src/sequence.ml
@@ -15,26 +15,33 @@ let[@inline always] sub a b =
 
 let[@inline always] window a b = sub a b
 
-let of_int32 x = Int32.to_int x land 0xFFFFFFFF
-let to_int32 = Int32.of_int
+(* project to 0 .. 0xffffffff, i.e. the positive part *)
+let of_int32 x =
+  let r = Int32.to_int x in
+  if x < 0l then r + 0x1_0000_0000 else r
 
-let[@inline always] less a b =
-  (a - b) land 0x80000000 <> 0
+let to_int32 x =
+  let r =
+    if x >= 0x80000000 then x - 0x1_0000_0000 else x
+  in
+  Int32.of_int r
 
-let[@inline always] less_equal a b =
-  let d = (a - b) land 0xFFFFFFFF in
-  d = 0 || d land 0x80000000 <> 0
+external ( < ) : 'a -> 'a -> bool = "%lessthan"
+external ( <= ) : 'a -> 'a -> bool = "%lessequal"
+external ( >= ) : 'a -> 'a -> bool = "%greaterequal"
+external ( > ) : 'a -> 'a -> bool = "%greaterthan"
 
-let[@inline always] greater a b =
-  let d = (a - b) land 0xFFFFFFFF in
-  d <> 0 && d land 0x80000000 = 0
+let[@inline always] less a b = a < b
 
-let[@inline always] greater_equal a b =
-  (a - b) land 0x80000000 = 0
+let[@inline always] less_equal a b = a <= b
+
+let[@inline always] greater a b = a > b
+
+let[@inline always] greater_equal a b = a >= b
 
 let equal a b = a == b
 
-let[@inline always] min a b = if less a b then a else b
-let[@inline always] max a b = if greater a b then a else b
+let[@inline always] min a b = if a <= b then a else b
+let[@inline always] max a b = if a >= b then a else b
 
 let pp = Fmt.int

--- a/src/sequence.ml
+++ b/src/sequence.ml
@@ -10,8 +10,8 @@ let zero = 0
 let[@inline always] addi a i = (add[@inlined]) a i
 
 let[@inline always] sub a b =
-  let d = (a - b) land 0xFFFFFFFF in
-  if d land 0x80000000 <> 0 then d - 0x1_0000_0000 else d
+  let d = a - b in
+  if d < 0 then d + 0x1_0000_0000 else d
 
 let[@inline always] window a b = sub a b
 

--- a/src/sequence.ml
+++ b/src/sequence.ml
@@ -27,21 +27,34 @@ let to_int32 x =
   Int32.of_int r
 
 external ( < ) : 'a -> 'a -> bool = "%lessthan"
-external ( <= ) : 'a -> 'a -> bool = "%lessequal"
-external ( >= ) : 'a -> 'a -> bool = "%greaterequal"
 external ( > ) : 'a -> 'a -> bool = "%greaterthan"
 
-let[@inline always] less a b = a < b
-
-let[@inline always] less_equal a b = a <= b
-
-let[@inline always] greater a b = a > b
-
-let[@inline always] greater_equal a b = a >= b
+let max_add = 1 lsl 31
 
 let equal a b = a == b
 
-let[@inline always] min a b = if a <= b then a else b
-let[@inline always] max a b = if a >= b then a else b
+let[@inline always] less a b =
+  not (equal a b) &&
+  (a < b && sub b a < max_add) ||
+  (a > b && sub a b > max_add)
+
+let[@inline always] less_equal a b =
+  equal a b || less a b
+
+let[@inline always] greater a b =
+  not (equal a b) &&
+  (a < b && sub b a > max_add) ||
+  (a > b && sub a b < max_add)
+
+let[@inline always] greater_equal a b =
+  equal a b || greater a b
+
+let[@inline always] min a b =
+  if sub a b > max_add then min a b else
+  if less a b then a else b
+
+let[@inline always] max a b =
+  if sub a b > max_add then max a b else
+  if greater a b then a else b
 
 let pp = Fmt.int

--- a/src/sequence.ml
+++ b/src/sequence.ml
@@ -9,28 +9,32 @@ let[@inline always] incr a = add a 1
 let zero = 0
 let[@inline always] addi a i = (add[@inlined]) a i
 
-external sub : t -> t -> int = "%subint"
-external window : t -> t -> int = "%subint"
+let[@inline always] sub a b =
+  let d = (a - b) land 0xFFFFFFFF in
+  if d land 0x80000000 <> 0 then d - 0x1_0000_0000 else d
+
+let[@inline always] window a b = sub a b
 
 let of_int32 x = Int32.to_int x land 0xFFFFFFFF
 let to_int32 = Int32.of_int
 
-external ( < ) : 'a -> 'a -> bool = "%lessthan"
-external ( <= ) : 'a -> 'a -> bool = "%lessequal"
-external ( >= ) : 'a -> 'a -> bool = "%greaterequal"
-external ( > ) : 'a -> 'a -> bool = "%greaterthan"
+let[@inline always] less a b =
+  (a - b) land 0x80000000 <> 0
 
-let ( > ) (x : int) y = x > y [@@inline]
-let ( < ) (x : int) y = x < y [@@inline]
-let ( <= ) (x : int) y = x <= y [@@inline]
-let ( >= ) (x : int) y = x >= y [@@inline]
-let min (a : int) b = if a <= b then a else b [@@inline]
-let max (a : int) b = if a >= b then a else b [@@inline]
+let[@inline always] less_equal a b =
+  let d = (a - b) land 0xFFFFFFFF in
+  d = 0 || d land 0x80000000 <> 0
 
-let less a b = a - b < 0
-let less_equal a b = a - b <= 0
-let greater a b = a - b > 0
-let greater_equal a b = a - b >= 0
+let[@inline always] greater a b =
+  let d = (a - b) land 0xFFFFFFFF in
+  d <> 0 && d land 0x80000000 = 0
+
+let[@inline always] greater_equal a b =
+  (a - b) land 0x80000000 = 0
+
 let equal a b = a == b
+
+let[@inline always] min a b = if less a b then a else b
+let[@inline always] max a b = if greater a b then a else b
 
 let pp = Fmt.int

--- a/src/sequence.ml
+++ b/src/sequence.ml
@@ -50,11 +50,9 @@ let[@inline always] greater_equal a b =
   equal a b || greater a b
 
 let[@inline always] min a b =
-  if sub a b > max_add then min a b else
   if less a b then a else b
 
 let[@inline always] max a b =
-  if sub a b > max_add then max a b else
   if greater a b then a else b
 
 let pp = Fmt.int

--- a/src/sequence.mli
+++ b/src/sequence.mli
@@ -1,5 +1,8 @@
 (* (c) 2017 Hannes Mehnert, all rights reserved *)
 
+(* TCP Sequence numbers are in the ring 0 .. 2 ^ 32 - 1. Especially the
+   comparison takes RFC 1982 (serial number arithmetics) into account. *)
+
 type t = private int [@@immediate]
 
 val of_int32 : int32 -> t

--- a/src/sequence.mli
+++ b/src/sequence.mli
@@ -11,8 +11,8 @@ val add : t -> t -> t
 val incr : t -> t
 
 val addi : t -> int -> t
-external sub : t -> t -> int = "%subint"
-external window : t -> t -> int = "%subint"
+val sub : t -> t -> int
+val window : t -> t -> int
 
 val less : t -> t -> bool
 val less_equal : t -> t -> bool

--- a/src/utcp.mli
+++ b/src/utcp.mli
@@ -38,7 +38,7 @@ val pp_flow : flow Fmt.t
     IP and port. *)
 val peers : flow -> (Ipaddr.t * int) * (Ipaddr.t * int)
 
-(** The module of TCP sequence numbers (unsigned 32 bit values, arithmetic operations may wrap) *)
+(** The module of TCP sequence numbers (unsigned 32 bit values, arithmetic operations may wrap), comparison adheres to serial number arithmetics from RFC 1982. *)
 module Sequence : sig
 
   (** The abstract type of a sequence number. *)

--- a/test/sequence.ml
+++ b/test/sequence.ml
@@ -41,28 +41,34 @@ let window_negative_within_wrap () =
   Alcotest.(check int) "window across wrap reversed = 0xffffffe0" 0xffffffe0 v
 
 let less_across_wrap () =
-  Alcotest.(check bool) "less 0xFFFFFFFF 0 = true" true (Sequence.less ffffffff z);
-  Alcotest.(check bool) "less 0 0xFFFFFFFF = false" false (Sequence.less z ffffffff)
+  Alcotest.(check bool) "less 0xFFFFFFFF 0 = false" false (Sequence.less ffffffff z);
+  Alcotest.(check bool) "less 0 0xFFFFFFFF = true" true (Sequence.less z ffffffff)
 
 let greater_across_wrap () =
-  Alcotest.(check bool) "greater 0 0xFFFFFFFF = true" true (Sequence.greater z ffffffff);
-  Alcotest.(check bool) "greater 0xFFFFFFFF 0 = false" false (Sequence.greater ffffffff z)
+  Alcotest.(check bool) "greater 0 0xFFFFFFFF = false" false (Sequence.greater z ffffffff);
+  Alcotest.(check bool) "greater 0xFFFFFFFF 0 = true" true (Sequence.greater ffffffff z)
 
 let less_equal_across_wrap () =
-  Alcotest.(check bool) "less_equal 0xFFFFFFFF 0 = true" true (Sequence.less_equal ffffffff z);
+  Alcotest.(check bool) "less_equal 0xFFFFFFFF 0 = false" false (Sequence.less_equal ffffffff z);
   Alcotest.(check bool) "less_equal 0xFFFFFFFF 0xFFFFFFFF = true" true (Sequence.less_equal ffffffff ffffffff);
-  Alcotest.(check bool) "less_equal 0 0xFFFFFFFF = false" false (Sequence.less_equal z ffffffff)
+  Alcotest.(check bool) "less_equal 0 0xFFFFFFFF = true" true (Sequence.less_equal z ffffffff)
 
 let greater_equal_across_wrap () =
-  Alcotest.(check bool) "greater_equal 0 0xFFFFFFFF = true" true (Sequence.greater_equal z ffffffff);
+  Alcotest.(check bool) "greater_equal 0 0xFFFFFFFF = false" false (Sequence.greater_equal z ffffffff);
   Alcotest.(check bool) "greater_equal 0 0 = true" true (Sequence.greater_equal z z);
-  Alcotest.(check bool) "greater_equal 0xFFFFFFFF 0 = false" false (Sequence.greater_equal ffffffff z)
+  Alcotest.(check bool) "greater_equal 0xFFFFFFFF 0 = true" true (Sequence.greater_equal ffffffff z)
 
 let min_across_wrap () =
-  Alcotest.(check seqno) "min 0xFFFFFFFF 0 = 0xFFFFFFFF" ffffffff (Sequence.min ffffffff z)
+  Alcotest.(check seqno) "min 0xFFFFFFFF 0 = 0" z (Sequence.min ffffffff z)
 
 let max_across_wrap () =
-  Alcotest.(check seqno) "max 0xFFFFFFFF 0 = 0" z (Sequence.max ffffffff z)
+  Alcotest.(check seqno) "max 0xFFFFFFFF 0 = 0xFFFFFFFF" ffffffff (Sequence.max ffffffff z)
+
+let to_of_int32 () =
+  Alcotest.(check seqno) "of_int32 (to_int32 0) = 0" z Sequence.(of_int32 (to_int32 z));
+  Alcotest.(check seqno) "of_int32 (to_int32 0xFFFFFFFF) = 0xFFFFFFFF" ffffffff Sequence.(of_int32 (to_int32 ffffffff));
+  Alcotest.(check seqno) "of_int32 (to_int32 0x7FFFFFFF) = 0x7FFFFFFF" (v 0x7fffffffl) Sequence.(of_int32 (to_int32 (v 0x7fffffffl)));
+  Alcotest.(check seqno) "of_int32 (to_int32 0x80000000) = 0x80000000" (v 0x80000000l) Sequence.(of_int32 (to_int32 (v 0x80000000l)))
 
 let tests = [
   "add wraps at 2^32",          `Quick, add_wraps_at_2_32 ;
@@ -77,4 +83,5 @@ let tests = [
   "greater_equal across wrap",  `Quick, greater_equal_across_wrap ;
   "min across wrap",            `Quick, min_across_wrap ;
   "max across wrap",            `Quick, max_across_wrap ;
+  "to and of int32",            `Quick, to_of_int32 ;
 ]

--- a/test/sequence.ml
+++ b/test/sequence.ml
@@ -1,0 +1,80 @@
+open Utcp
+
+(* Tests about sequence number. *)
+
+let max_seq = 0xFFFFFFFFl
+
+let v = Sequence.of_int32
+let ffffffff = v max_seq
+let z = v 0l
+let i32 = Sequence.to_int32
+
+let seqno =
+  let pp = Fmt.using i32 Fmt.int32 in
+  let equal a b = Int32.equal (i32 a) (i32 b) in
+  Alcotest.testable pp equal
+
+let add_wraps_at_2_32 () =
+  let v = Sequence.(add ffffffff (v 1l)) in
+  Alcotest.(check seqno) "0xFFFFFFFF + 1 = 0" Sequence.zero v
+
+let incr_wraps_at_2_32 () =
+  let v = Sequence.incr ffffffff in
+  Alcotest.(check seqno) "incr 0xFFFFFFFF = 0" Sequence.zero v
+
+let sub_across_wrap_forward () =
+  let v = Sequence.window z ffffffff in
+  Alcotest.(check int) "sub 0 0xFFFFFFFF = 1" 1 v
+
+let sub_across_wrap_backward () =
+  let v = Sequence.window ffffffff z in
+  Alcotest.(check int) "sub 0xFFFFFFFF 0 = -1" (-1) v
+
+let window_within_wrap () =
+  let snd_una = v 0xFFFFFFF0l and snd_nxt = v 0x10l in
+  let v = Sequence.window snd_nxt snd_una in
+  Alcotest.(check int) "window across wrap = 0x20" 0x20 v
+
+let window_negative_within_wrap () =
+  let snd_una = v 0xFFFFFFF0l and snd_nxt = v 0x10l in
+  let v = Sequence.window snd_una snd_nxt in
+  Alcotest.(check int) "window across wrap reversed = -0x20" (-0x20) v
+
+let less_across_wrap () =
+  Alcotest.(check bool) "less 0xFFFFFFFF 0 = true" true (Sequence.less ffffffff z);
+  Alcotest.(check bool) "less 0 0xFFFFFFFF = false" false (Sequence.less z ffffffff)
+
+let greater_across_wrap () =
+  Alcotest.(check bool) "greater 0 0xFFFFFFFF = true" true (Sequence.greater z ffffffff);
+  Alcotest.(check bool) "greater 0xFFFFFFFF 0 = false" false (Sequence.greater ffffffff z)
+
+let less_equal_across_wrap () =
+  Alcotest.(check bool) "less_equal 0xFFFFFFFF 0 = true" true (Sequence.less_equal ffffffff z);
+  Alcotest.(check bool) "less_equal 0xFFFFFFFF 0xFFFFFFFF = true" true (Sequence.less_equal ffffffff ffffffff);
+  Alcotest.(check bool) "less_equal 0 0xFFFFFFFF = false" false (Sequence.less_equal z ffffffff)
+
+let greater_equal_across_wrap () =
+  Alcotest.(check bool) "greater_equal 0 0xFFFFFFFF = true" true (Sequence.greater_equal z ffffffff);
+  Alcotest.(check bool) "greater_equal 0 0 = true" true (Sequence.greater_equal z z);
+  Alcotest.(check bool) "greater_equal 0xFFFFFFFF 0 = false" false (Sequence.greater_equal ffffffff z)
+
+let min_across_wrap () =
+  Alcotest.(check seqno) "min 0xFFFFFFFF 0 = 0xFFFFFFFF" ffffffff (Sequence.min ffffffff z)
+
+let max_across_wrap () =
+  Alcotest.(check seqno) "max 0xFFFFFFFF 0 = 0" z (Sequence.max ffffffff z)
+
+let tests = [
+  "add wraps at 2^32",          `Quick, add_wraps_at_2_32 ;
+  "incr wraps at 2^32",         `Quick, incr_wraps_at_2_32 ;
+  "sub across wrap forward",    `Quick, sub_across_wrap_forward ;
+  "sub across wrap backward",   `Quick, sub_across_wrap_backward ;
+  "window within wrap",         `Quick, window_within_wrap ;
+  "window negative within wrap",`Quick, window_negative_within_wrap ;
+  "less across wrap",           `Quick, less_across_wrap ;
+  "greater across wrap",        `Quick, greater_across_wrap ;
+  "less_equal across wrap",     `Quick, less_equal_across_wrap ;
+  "greater_equal across wrap",  `Quick, greater_equal_across_wrap ;
+  "min across wrap",            `Quick, min_across_wrap ;
+  "max across wrap",            `Quick, max_across_wrap ;
+]

--- a/test/sequence.ml
+++ b/test/sequence.ml
@@ -60,10 +60,10 @@ let greater_equal_across_wrap () =
   Alcotest.(check bool) "greater_equal 0xFFFFFFFF 0 = false" false (Sequence.greater_equal ffffffff z)
 
 let min_across_wrap () =
-  Alcotest.(check seqno) "min 0xFFFFFFFF 0 = 0" z (Sequence.min ffffffff z)
+  Alcotest.(check seqno) "min 0xFFFFFFFF 0 = 0xFFFFFFFF" ffffffff (Sequence.min ffffffff z)
 
 let max_across_wrap () =
-  Alcotest.(check seqno) "max 0xFFFFFFFF 0 = 0xFFFFFFFF" ffffffff (Sequence.max ffffffff z)
+  Alcotest.(check seqno) "max 0xFFFFFFFF 0 = 0" z (Sequence.max ffffffff z)
 
 let to_of_int32 () =
   Alcotest.(check seqno) "of_int32 (to_int32 0) = 0" z Sequence.(of_int32 (to_int32 z));

--- a/test/sequence.ml
+++ b/test/sequence.ml
@@ -41,22 +41,23 @@ let window_negative_within_wrap () =
   Alcotest.(check int) "window across wrap reversed = 0xffffffe0" 0xffffffe0 v
 
 let less_across_wrap () =
-  Alcotest.(check bool) "less 0xFFFFFFFF 0 = false" false (Sequence.less ffffffff z);
-  Alcotest.(check bool) "less 0 0xFFFFFFFF = true" true (Sequence.less z ffffffff)
+  Alcotest.(check bool) "less 0xFFFFFFFF 0 = true" true (Sequence.less ffffffff z);
+  Alcotest.(check bool) "less 0xFFFFFFFF 0xFFFFFFFE = false" false (Sequence.less ffffffff (v 0xfffffffel));
+  Alcotest.(check bool) "less 0 0xFFFFFFFF = false" false (Sequence.less z ffffffff)
 
 let greater_across_wrap () =
-  Alcotest.(check bool) "greater 0 0xFFFFFFFF = false" false (Sequence.greater z ffffffff);
-  Alcotest.(check bool) "greater 0xFFFFFFFF 0 = true" true (Sequence.greater ffffffff z)
+  Alcotest.(check bool) "greater 0 0xFFFFFFFF = true" true (Sequence.greater z ffffffff);
+  Alcotest.(check bool) "greater 0xFFFFFFFF 0 = false" false (Sequence.greater ffffffff z)
 
 let less_equal_across_wrap () =
-  Alcotest.(check bool) "less_equal 0xFFFFFFFF 0 = false" false (Sequence.less_equal ffffffff z);
+  Alcotest.(check bool) "less_equal 0xFFFFFFFF 0 = true" true (Sequence.less_equal ffffffff z);
   Alcotest.(check bool) "less_equal 0xFFFFFFFF 0xFFFFFFFF = true" true (Sequence.less_equal ffffffff ffffffff);
-  Alcotest.(check bool) "less_equal 0 0xFFFFFFFF = true" true (Sequence.less_equal z ffffffff)
+  Alcotest.(check bool) "less_equal 0 0xFFFFFFFF = false" false (Sequence.less_equal z ffffffff)
 
 let greater_equal_across_wrap () =
-  Alcotest.(check bool) "greater_equal 0 0xFFFFFFFF = false" false (Sequence.greater_equal z ffffffff);
+  Alcotest.(check bool) "greater_equal 0 0xFFFFFFFF = true" true (Sequence.greater_equal z ffffffff);
   Alcotest.(check bool) "greater_equal 0 0 = true" true (Sequence.greater_equal z z);
-  Alcotest.(check bool) "greater_equal 0xFFFFFFFF 0 = true" true (Sequence.greater_equal ffffffff z)
+  Alcotest.(check bool) "greater_equal 0xFFFFFFFF 0 = false" false (Sequence.greater_equal ffffffff z)
 
 let min_across_wrap () =
   Alcotest.(check seqno) "min 0xFFFFFFFF 0 = 0" z (Sequence.min ffffffff z)

--- a/test/sequence.ml
+++ b/test/sequence.ml
@@ -28,7 +28,7 @@ let sub_across_wrap_forward () =
 
 let sub_across_wrap_backward () =
   let v = Sequence.window ffffffff z in
-  Alcotest.(check int) "sub 0xFFFFFFFF 0 = -1" (-1) v
+  Alcotest.(check int) "sub 0xFFFFFFFF 0 = 0xffffffff" 0xffffffff v
 
 let window_within_wrap () =
   let snd_una = v 0xFFFFFFF0l and snd_nxt = v 0x10l in
@@ -38,7 +38,7 @@ let window_within_wrap () =
 let window_negative_within_wrap () =
   let snd_una = v 0xFFFFFFF0l and snd_nxt = v 0x10l in
   let v = Sequence.window snd_una snd_nxt in
-  Alcotest.(check int) "window across wrap reversed = -0x20" (-0x20) v
+  Alcotest.(check int) "window across wrap reversed = 0xffffffe0" 0xffffffe0 v
 
 let less_across_wrap () =
   Alcotest.(check bool) "less 0xFFFFFFFF 0 = true" true (Sequence.less ffffffff z);

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -2,6 +2,7 @@
 
 let tests = [
   "Checksum", Checksum.tests ;
+  "Sequence", Sequence.tests ;
   "State machine", State_machine.tests ;
   "Reassembly", Reassembly.tests ;
   "Rope", Rope.tests ;


### PR DESCRIPTION
I observed some strange behaviors when I did some benchmark with `iperf3`. That's the good implementation of the sequence number, we must _cap_ some overflows when we manipulate `int63`.