### PR TITLE
Lint dependencies

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,5 +1,5 @@
 (library
  (name utcp)
  (public_name utcp)
- (libraries cstruct fmt ipaddr ipaddr-cstruct logs randomconv duration mtime metrics base64 mirage-crypto-rng)
+ (libraries cstruct fmt ipaddr logs randomconv duration mtime metrics base64 mirage-crypto-rng)
  (instrumentation (backend bisect_ppx)))


### PR DESCRIPTION
Catched by `unic`, the `utcp` library does not requires `ipaddr-cstruct`.