### PR TITLE
Half close

### DIFF
--- a/src/input.ml
+++ b/src/input.ml
@@ -1171,8 +1171,8 @@ let handle_buf t now ~src ~dst data =
       (* impossible case, if [is_present = false], [is_established == false]
          also (see when we introspect [new_conn]). If [was_present = false],
          [was_established == false] also (see when we introspect [old_conn]). *)
-      | _, true, _, false -> assert false
-      | true, _, false, _ -> assert false
+      | _, true, _, false -> None
+      | true, _, false, _ -> None
       | false, true, _, _ ->
         (* active open, there's likely someone waiting *)
         let cond = if was_syn_sent then rcv_n else None in

--- a/src/input.ml
+++ b/src/input.ml
@@ -1186,7 +1186,14 @@ let handle_buf t now ~src ~dst data =
           | None -> None, None
           | Some s -> Some s.rcv_notify, Some s.snd_notify
         in
-        Some (`Drop (id, None, Option.to_list rcv_n @ Option.to_list snd_n))
+        (* here, we preserve the same semantic as below, if [rcv_data || rcvd_fin],
+           we shoud notify [Ok _] to the reader. Otherwise, we notify [Eof]. *)
+        let opt, ns =
+          if rcv_data || rcvd_fin
+          then rcv_n, []
+          else None, Option.to_list rcv_n in
+        let ns = ns @ Option.to_list snd_n in
+        Some (`Drop (id, opt, ns))
       | _, _, false, false ->
         (* nothing to do, the connection is not present and was not. *)
         None

--- a/src/input.ml
+++ b/src/input.ml
@@ -1140,13 +1140,15 @@ let handle_buf t now ~src ~dst data =
     (* deliver_in_3a deliver_in_4 are done now! *)
     let t', outs = handle_segment t now id seg in
     let ev =
+      let old_conn = CM.find_opt id t.connections in
+      let new_conn = CM.find_opt id t'.connections in
       let was_established, was_syn_sent, was_present =
-        match CM.find_opt id t.connections with
+        match old_conn with
         | None -> false, false, false
         | Some s -> s.tcp_state = Established, s.tcp_state = Syn_sent, true
       in
       let is_established, is_present, rcv_data, snd_space, rcv_n, snd_n =
-        match CM.find_opt id t'.connections with
+        match new_conn with
         | None -> false, false, false, false, None, None
         | Some s ->
           s.tcp_state = Established,
@@ -1155,23 +1157,42 @@ let handle_buf t now ~src ~dst data =
           Rope.length s.sndq < s.sndbufsize,
           Some s.rcv_notify, Some s.snd_notify
       in
+      let rcvd_fin =
+        (* the peer shut down its write side (half-close): a pending reader
+           must be woken up (it will drain the remaining data and observe
+           Eof on the next recv), but the connection stays usable for
+           sending (CLOSE_WAIT). See [di3_ststuff] to see when we set
+           [cantrcvmore]. *)
+        match old_conn, new_conn with
+        | Some o, Some n -> not o.cantrcvmore && n.cantrcvmore
+        | _ -> false
+      in
       match was_established, is_established, was_present, is_present with
+      (* impossible case, if [is_present = false], [is_established == false]
+         also (see when we introspect [new_conn]). If [was_present = false],
+         [was_established == false] also (see when we introspect [old_conn]). *)
+      | _, true, _, false -> assert false
+      | true, _, false, _ -> assert false
       | false, true, _, _ ->
         (* active open, there's likely someone waiting *)
         let cond = if was_syn_sent then rcv_n else None in
         Some (`Established (id, cond))
-      | true, false, _, _
-      | _, _, true, false ->
-        let opt_cond, conds =
-          if rcv_data then
-            rcv_n, Option.to_list snd_n
-          else
-            None, Option.to_list rcv_n @ Option.to_list snd_n
+      | _, false, true, false ->
+        (* the connection disappeared (RST or final close): every waiter must
+           be woken up with Eof. The notify conditions are taken from the
+           previous state since the connection no longer exists in [t']. *)
+        let rcv_n, snd_n =
+          match old_conn with
+          | None -> None, None
+          | Some s -> Some s.rcv_notify, Some s.snd_notify
         in
-        Some (`Drop (id, opt_cond, conds))
-      | _ ->
+        Some (`Drop (id, None, Option.to_list rcv_n @ Option.to_list snd_n))
+      | _, _, false, false ->
+        (* nothing to do, the connection is not present and was not. *)
+        None
+      | _, _, _, true ->
         match
-          (if rcv_data then Option.to_list rcv_n else []) @
+          (if rcv_data || rcvd_fin then Option.to_list rcv_n else []) @
           (if snd_space then Option.to_list snd_n else [])
         with
         | [] -> None

--- a/test/state_machine.ml
+++ b/test/state_machine.ml
@@ -387,7 +387,6 @@ let run_timers tcp now n =
   in
   go tcp [] [] n
 
-
 let test_window_probe =
   (* NOTE(dinosaure): here, we are the receiver and our receive buffer fills
      up ([rcv_wnd] = 0, it becomes full). The peer is in persist mode and sends
@@ -509,5 +508,105 @@ let test_window_probe =
   ; "out-of-window RST is dropped", `Quick,
     rst_out_of_window_is_dropped ]
 
+let test_close_wait =
+  let now = Mtime.of_uint64_ns 0L in
+  let handle tcp seg =
+    let data = Segment.encode_and_checksum now ~src:your_ip ~dst:my_ip seg in
+    handle_buf tcp now ~src:your_ip ~dst:my_ip data
+  in
+  let established () =
+    let ctr = ref 0 in
+    let fetch_and_incr () = incr ctr; !ctr in
+    let tcp = start_listen (empty fetch_and_incr "") listen_port in
+    let syn = { basic_seg with flag = Some `Syn ; seq = initial_seq } in
+    (* SYN ([out] should be SYN+ACK) *)
+    let tcp, _ev, _out = handle tcp syn in
+    let ack = { basic_seg with seq = Sequence.incr initial_seq ;
+                               ack = Some (Sequence.incr rng_seq) ;
+                               window = 1 lsl 16 - 1 } in
+    (* ACK (we should be in the [Established] mode) *)
+    let tcp, ev, _out = handle tcp ack in
+    let id = match ev with
+      | Some (`Established (id, None)) -> id
+      | _ -> Alcotest.fail "expected an ESTABLISHED event"
+    in
+    let tcp, rcv_cond = match recv tcp now id with
+      | Ok (tcp, _, cond, _) -> tcp, cond
+      | Error _ -> Alcotest.fail "recv failed"
+    in
+    let tcp, snd_cond = match send tcp now id "" with
+      | Ok (tcp, _, cond, _) -> tcp, cond
+      | Error _ -> Alcotest.fail "send failed"
+    in
+    tcp, id, rcv_cond, snd_cond
+  in
+  let fin = { basic_seg with flag = Some `Fin ; push = true ;
+                             seq = Sequence.incr initial_seq ;
+                             ack = Some (Sequence.incr rng_seq) ;
+                             window = 1 lsl 16 - 1 ;
+                             payload_len = 4 ; payload = [ "bye!" ] }
+  and rst = { basic_seg with flag = Some `Rst ;
+                             seq = Sequence.incr initial_seq }
+  in
+  let fin_on_established () =
+    (* NOTE(dinosaure): the aim here is to demonstrate that a client can
+       'half-close' a connection. In other words, the client signals that it
+       will no longer send any bytes, but the server can still send data. We
+       must also ensure that the 'conditions' are properly released.
+
+       [C]: Client
+       [S]: Server
+       [s]: state of the server
+
+       C: SYN ->            ACK -> FIN ->
+       S:        SYN+ACK ->     |               ACK ->
+       s:                       | [ESTABLISHED]     | [CLOSE_WAIT] *)
+    let tcp, id, rcv_cond, snd_cond = established () in
+    (* FIN ([out] should be ACK) *)
+    let tcp, ev, _out = handle tcp fin in
+    begin match ev with
+    | Some (`Signal (_, conds)) ->
+      Alcotest.(check (list int)) "the reader (and writer) is woken up"
+        [ rcv_cond ; snd_cond ] conds
+    | Some (`Drop _) -> Alcotest.fail "unexpected drop"
+    | _ -> Alcotest.fail "expected a signal" end;
+    (* NOTE(dinosaure: The reader drains the pending data, and must observes
+       [Eof] then. *)
+    let tcp = match recv tcp now id with
+      | Ok (tcp, bufs, _, _) ->
+        Alcotest.(check string) "bye!"
+          "bye!" (String.concat "" bufs) ;
+        tcp
+      | Error _ -> Alcotest.fail "expected recv to deliver the pending data"
+    in
+    let tcp = match recv tcp now id with
+      | Error `Eof -> tcp
+      | Ok _ -> Alcotest.fail "expected eof"
+      | Error _ -> Alcotest.fail "expected eof"
+    in
+    (* NOTE(dinosaure): half-close: the connection is still usable for sending
+       bytes by the server. *)
+    match send tcp now id "ok" with
+    | Ok (_, 2, _, _) -> ()
+    | Ok _ -> Alcotest.fail "impossible to send data in CLOSE_WAIT"
+    | Error _ -> Alcotest.fail "impossible to send data in CLOSE_WAIT" in
+  let rst_on_established () =
+    (* NOTE(dinosaure): the aim here is to show that we are correctly consuming
+       our conditions despite an [RST] being sent by the client. *)
+    let tcp, id, rcv_cond, snd_cond = established () in
+    let tcp, ev, _out = handle tcp rst in
+    begin match ev with
+    | Some (`Drop (_, None, conds)) ->
+      Alcotest.(check (list int)) "all waiters are woken up with eof"
+        [ rcv_cond ; snd_cond ] conds
+    | Some (`Drop (_, Some _, _)) ->
+      Alcotest.fail "we don't have any readers"
+    | _ -> Alcotest.fail "expected a drop event on RST reception" end;
+    match recv tcp now id with
+    | Error `Not_found -> ()
+    | _ -> Alcotest.fail "unexpected connection" in
+  [ "FIN in Established signals, does not drop", `Quick, fin_on_established
+  ; "RST in Established drops and wakes all waiters", `Quick, rst_on_established ]
+
 let tests =
-  test_closed @ test_listen @ test_syn_sent @ test_syn_rcvd @ test_window_probe
+  test_closed @ test_listen @ test_syn_sent @ test_syn_rcvd @ test_window_probe @ test_close_wait


### PR DESCRIPTION
This pull request attempts to fix an issue I observed on the echo server (available [here](https://github.com/robur-coop/mnet/blob/main/unikernels/echo/echo.ml)) and relates to how `utcp` handles the `CLOSE_WAIT` state. From what I’ve noticed, the “conditions” relating to reading and writing when a FIN is received are never resumed by the user: there is therefore some fibers waiting _ad vitam aeternam_ to read from or write to the connection.

The first challenge was to characterise this situation in the pattern-matching, so I made the pattern exhaustive (and removed the `| _ -> ...` case, which didn’t make much sense to me).

Next, in the event of a FIN being received, I extended the last case (`_, _, _, true -> is_present`) to still return a `Signal` in order to allow the user to complete the read operation even though the connection is half-closed.

Finally, there is the RST case, which must terminate the connection but, more importantly, return the correct conditions (previously, we were trying to retrieve them from the new connection state even though the connection no longer existed... we now retrieve them from the connection’s previous state) so that the user can unblock read/write access on the connection (and ultimately receive an `Eof` or `Closed_by_peer`).

Finally, I have simulated both cases in `test/state_machine.ml` and can confirm that neither works without this patch. It remains to be seen whether this patch is correct or not :+1:!