### PR TITLE
Fix how we start the persist timer

### DIFF
--- a/src/segment.ml
+++ b/src/segment.ml
@@ -327,7 +327,7 @@ let tcp_output_required now conn =
     cb.State.tf_shouldacknow
   in
   let persist_fun =
-    let cant_send = not do_output && Rope.length conn.sndq = 0 && cb.State.tt_rexmt = None in
+    let cant_send = not do_output && Rope.length conn.sndq <> 0 && cb.State.tt_rexmt = None in
     let window_shrunk = win = 0 && snd_wnd_unused < 0 in  (*: [[win = 0]] if in [[SYN_SENT]], but still may send FIN :*)
                                                      (* (bsd_arch arch ==> tcp_sock.st <> SYN_SENT)) in *)
     if cant_send then  (* takes priority over window_shrunk; note this needs to be checked *)


### PR DESCRIPTION
See the specification here:
https://github.com/rems-project/netsem/blob/0b02450eee334fc42f74ad3da09d3ce1a0698a48/specification/TCP1_auxFnsScript.sml#L1597

A simple typo (between <> and =)! As far as I searched, this typo exists since the beginning of utcp.

As requested, found when I experimented with window-probe/persistent connection on #75.